### PR TITLE
docs(ui): A1 UI mapping definitions (docs + template)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,9 +1,9 @@
 # AI Context
-- 最終更新: 2025-10-05T03:21:37+09:00
-- 現在のミッション: フェーズ1: 中央ワークフロー統合 (#TBD)
-- ブランチ: chore/central-integration
-- 関連: Issue TBD, PR TBD
-- 進捗: 40% / ステータス: 実装中（CI/Docs追加）
+- 最終更新: 2025-10-05T04:18:04+09:00
+- 現在のミッション: フェーズ2: Sprint 02 [A1] 旧→新 UI マッピング定義 (#11)
+- ブランチ: feat/ui-mapping-a1
+- 関連: Issue https://github.com/YuShimoji/VastCore/issues/11, PR TBD
+- 進捗: 60% / ステータス: 実装中（設計書/テンプレ追加、PR準備）
 - 次の中断可能点: PR 作成後、CI 成功待ち
 
 ## 決定事項

--- a/docs/SPRINT_PLAN_02.md
+++ b/docs/SPRINT_PLAN_02.md
@@ -1,0 +1,24 @@
+# Sprint 02 計画
+
+- **[A] 旧UI → Vastcore.UI 置換ルール**
+  - 目的: 旧 `NarrativeGen.UI` から新 `Vastcore.UI` への安全な移行（GUID維持・最小差分）。
+  - 構成:
+    - [A1] 旧→新 UI マッピング定義（ドキュメント/JSON雛形）
+      - 成果物: `docs/ui-migration/OLD_TO_NEW_UI_MAPPING.md`, `docs/ui-migration/ui_mapping_rules.template.json`
+      - DoD: ドキュメントとテンプレ追加、CI パス、Issue/PR 更新
+      - 状態: 着手済（本PRで追加）
+    - [A2] 検出スキャナの強化と半自動置換ツールの実装（dry-run/レポート出力）
+      - JSONルールを読み込み、対象検出と変更プランを生成（適用はdry-run）
+      - 状態: 未着手（A1完了後に開始）
+    - [A3] 段階適用と検証
+      - 限定適用→ビルド/シーン動作確認→レポート反映
+      - 状態: 未着手
+
+- **管理**
+  - 追跡: Issue #11（A1）
+  - ブランチ: `feat/ui-mapping-a1`
+  - CI: 共有ワークフロー `ci-smoke` によりスモーク実行
+
+- **リスク/緩和**
+  - 自動置換の誤変換 → A2はdry-run限定から開始、A3で限定適用
+  - asmdef/rootNamespace の整合 → A1はルール定義のみ。適用はA2/A3で段階導入

--- a/docs/ui-migration/OLD_TO_NEW_UI_MAPPING.md
+++ b/docs/ui-migration/OLD_TO_NEW_UI_MAPPING.md
@@ -1,0 +1,61 @@
+# 旧→新 UI マッピング定義（A1 設計書）
+
+## 目的
+- 旧 `NarrativeGen.UI` から新 `Vastcore.UI` への移行ルールを定義する。
+- GUIDやアセット参照を壊さず、最小差分（ファイル移動なし、namespace変更中心）で移行する。
+
+## スコープ
+- C# namespace の統一: `NarrativeGen.UI` → `Vastcore.UI`。
+- 例外: `MenuManager` は `Vastcore.UI.Menus`（サブ名前空間）へ移行。
+- CreateAssetMenu の `menuName` を `Vastcore/UI/...` に統一（新規追加時）。既存アセットのGUIDは保持。
+- asmdef: `Vastcore.UI.asmdef`（rootNamespace=`Vastcore.UI`）を前提。必要なら将来の[A2]で調整。
+
+## ルール体系
+- Namespace 置換規則
+  - 基本: `NarrativeGen.UI` → `Vastcore.UI`
+  - ピンポイント: `NarrativeGen.UI.MenuManager` → `Vastcore.UI.Menus.MenuManager`
+- クラス名の変更
+  - 現時点ではクラス名自体は維持（名前空間のみ変更）。
+- 属性（CreateAssetMenu）の調整
+  - `menuName` 先頭を `Vastcore/UI/` に統一。
+- ファイル/GUID
+  - ファイルの移動は行わない。GUIDは保持。メタ参照破壊を避ける。
+
+## JSON ルール形式（雛形）
+- `version`: スキーマバージョン。
+- `namespaceMappings[]`: { from, to, includePattern? }
+- `classMappings[]`: { fromQualified, toQualified, note? }
+- `attributeRules[]`: { attribute, fields: { fieldName: { replaceRegexFrom, replaceTo, setIfMissing? } } }
+- `constraints`: { preserveGUID: true, moveFiles: false }
+- `validation`: { compile: true, scenesSmoke: ["Assets/Scenes/Main.unity"] }
+
+### 例（抜粋）
+```json
+{
+  "version": "1.0",
+  "namespaceMappings": [
+    { "from": "NarrativeGen.UI", "to": "Vastcore.UI" }
+  ],
+  "classMappings": [
+    { "fromQualified": "NarrativeGen.UI.MenuManager", "toQualified": "Vastcore.UI.Menus.MenuManager", "note": "サブ名前空間へ集約" }
+  ],
+  "attributeRules": [
+    {
+      "attribute": "UnityEngine.CreateAssetMenuAttribute",
+      "fields": {
+        "menuName": { "replaceRegexFrom": "^NarrativeGen/", "replaceTo": "Vastcore/" }
+      }
+    }
+  ],
+  "constraints": { "preserveGUID": true, "moveFiles": false },
+  "validation": { "compile": true, "scenesSmoke": ["Assets/Scenes/Main.unity"] }
+}
+```
+
+## 運用
+- 手動レビュー優先（自動置換は[A2]以降で工具化）。
+- テスト: コンパイル無エラー、コアシーンで UI 基本挙動を確認。
+
+## 既知の例外/補足
+- `MenuManager` は `Vastcore.UI.Menus` へ。その他は `Vastcore.UI`。
+- 将来拡張: asmdef の参照と rootNamespace の整備、PlayMode テスト導入。

--- a/docs/ui-migration/ui_mapping_rules.template.json
+++ b/docs/ui-migration/ui_mapping_rules.template.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0",
+  "namespaceMappings": [
+    { "from": "NarrativeGen.UI", "to": "Vastcore.UI" }
+  ],
+  "classMappings": [
+    { "fromQualified": "NarrativeGen.UI.MenuManager", "toQualified": "Vastcore.UI.Menus.MenuManager", "note": "サブ名前空間へ集約" }
+  ],
+  "attributeRules": [
+    {
+      "attribute": "UnityEngine.CreateAssetMenuAttribute",
+      "fields": {
+        "menuName": { "replaceRegexFrom": "^NarrativeGen/", "replaceTo": "Vastcore/" }
+      }
+    }
+  ],
+  "constraints": { "preserveGUID": true, "moveFiles": false },
+  "validation": { "compile": true, "scenesSmoke": ["Assets/Scenes/Main.unity"] },
+  "$comment": "テンプレート: 必要に応じて項目を追記。"
+}


### PR DESCRIPTION
Implements Sprint 02 [A1]: oldnew UI mapping definitions.\n\nChanges:\n- Add docs/ui-migration/OLD_TO_NEW_UI_MAPPING.md\n- Add docs/ui-migration/ui_mapping_rules.template.json\n- Update AI_CONTEXT.md and docs/SPRINT_PLAN_02.md\n\nTesting:\n- CI smoke only (docs changes)\n\nRisk:\n- None (docs only)\n\nCloses #11