### PR TITLE
docs: AI_CONTEXT timestamp refresh (post-A2)

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,11 +1,10 @@
 # AI Context
-- 最終更新: 2025-10-05T16:50:19+09:00
+ - 最終更新: 2025-10-05T19:16:56+09:00
  - 現在のミッション: フェーズ2: Sprint 02 [A2] 検出スキャナの強化と半自動置換ツールの実装（完了）
  - ブランチ: develop
  - 関連: Issue https://github.com/YuShimoji/VastCore/issues/13, PR https://github.com/YuShimoji/VastCore/pull/14（マージ済）
  - 進捗: 100% / ステータス: 完了（CIパス＆自動マージ）
  - 次の予定: [A3] 段階適用と検証（限定適用→ビルド/シーン動作確認→レポート反映）
-
 ## 決定事項
 - 共有ワークフロー `ci-smoke.yml`/`sync-issues.yml` を再利用する。
 - Node の簡易 dev server / smoke check を本リポジトリに追加して CI 成功を保証。


### PR DESCRIPTION
Docs-only: refresh AI_CONTEXT.md timestamp to current time after A2 merge.\nIncludes no code changes.\n\nBase: develop\nHead: chore/a2-docs-status-update