### PR TITLE
feat(terrain): M1 provider architecture (Noise) [closes #29]

### DIFF
--- a/Assets/Scripts/Terrain/Config/HeightmapProviderSettings.cs
+++ b/Assets/Scripts/Terrain/Config/HeightmapProviderSettings.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Terrain.Config
+{
+    /// <summary>
+    /// Heightmap プロバイダ設定の抽象基底。
+    /// 設定アセットからプロバイダを生成する Factory を提供します。
+    /// </summary>
+    public abstract class HeightmapProviderSettings : ScriptableObject
+    {
+        public abstract IHeightmapProvider CreateProvider();
+    }
+}

--- a/Assets/Scripts/Terrain/Config/NoiseHeightmapSettings.cs
+++ b/Assets/Scripts/Terrain/Config/NoiseHeightmapSettings.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Terrain.Config
+{
+    [CreateAssetMenu(fileName = "NoiseHeightmapSettings", menuName = "Vastcore/Terrain/Noise Heightmap Settings")]
+    public sealed class NoiseHeightmapSettings : HeightmapProviderSettings
+    {
+        [Header("Noise (FBM)")] public int seed = 12345;
+        [Min(0.001f)] public float scale = 200f;
+        [Range(1, 12)] public int octaves = 5;
+        [Min(1.0f)] public float lacunarity = 2.0f;
+        [Range(0.0f, 1.0f)] public float gain = 0.5f;
+        public Vector2 offset = Vector2.zero;
+
+        [Header("Domain Warp (optional)")] public bool domainWarp = false;
+        [Min(0f)] public float warpStrength = 10f;
+        [Min(0.00001f)] public float warpFrequency = 0.01f;
+
+        public override IHeightmapProvider CreateProvider()
+        {
+            return new NoiseHeightmapProvider(
+                seed,
+                scale,
+                octaves,
+                lacunarity,
+                gain,
+                offset,
+                domainWarp,
+                warpStrength,
+                warpFrequency
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/Config/TerrainGenerationConfig.cs
+++ b/Assets/Scripts/Terrain/Config/TerrainGenerationConfig.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Terrain.Config
+{
+    [CreateAssetMenu(fileName = "TerrainGenerationConfig", menuName = "Vastcore/Terrain/Generation Config")]
+    public sealed class TerrainGenerationConfig : ScriptableObject
+    {
+        [Header("Heightmap")]
+        public HeightmapProviderSettings heightmapSettings;
+        [Min(2)] public int resolution = 257; // Unity Terrain は 2^n+1 が扱いやすい
+        [Min(1f)] public float worldSize = 256f; // 1 チャンクの横幅（m）
+        [Min(1f)] public float heightScale = 100f; // 地形の高さ（m）
+
+        public IHeightmapProvider CreateHeightProvider()
+        {
+            if (heightmapSettings == null)
+            {
+                Debug.LogError("TerrainGenerationConfig.heightmapSettings is null");
+                return null;
+            }
+            return heightmapSettings.CreateProvider();
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/Providers/IHeightmapProvider.cs
+++ b/Assets/Scripts/Terrain/Providers/IHeightmapProvider.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace Vastcore.Terrain.Providers
+{
+    /// <summary>
+    /// 抽象化された高さデータ供給源。出力は [0,1] 正規化。
+    /// worldOrigin/worldSize はワールド座標系で一貫。
+    /// </summary>
+    public interface IHeightmapProvider
+    {
+        /// <summary>
+        /// 出力配列 heights の長さは resolution*resolution を期待。
+        /// インデクスは x + y*resolution（x:0..res-1, y:0..res-1）。
+        /// </summary>
+        void Generate(float[] heights, int resolution, Vector2 worldOrigin, float worldSize, in HeightmapGenerationContext context);
+    }
+
+    /// <summary>
+    /// 生成時のコンテキスト（seed など）。
+    /// </summary>
+    public struct HeightmapGenerationContext
+    {
+        public int Seed;
+    }
+}

--- a/Assets/Scripts/Terrain/Providers/NoiseHeightmapProvider.cs
+++ b/Assets/Scripts/Terrain/Providers/NoiseHeightmapProvider.cs
@@ -1,0 +1,119 @@
+using UnityEngine;
+
+namespace Vastcore.Terrain.Providers
+{
+    /// <summary>
+    /// ノイズ(FBM)ベースの高さ供給。ワールド座標系ベースでサンプルするため、
+    /// チャンク間の継ぎ目が出にくい設計。
+    /// </summary>
+    public sealed class NoiseHeightmapProvider : IHeightmapProvider
+    {
+        private readonly int _seed;
+        private readonly float _scale;
+        private readonly int _octaves;
+        private readonly float _lacunarity;
+        private readonly float _gain;
+        private readonly Vector2 _offset;
+        private readonly bool _domainWarp;
+        private readonly float _warpStrength;
+        private readonly float _warpFrequency;
+
+        public NoiseHeightmapProvider(
+            int seed,
+            float scale,
+            int octaves,
+            float lacunarity,
+            float gain,
+            Vector2 offset,
+            bool domainWarp = false,
+            float warpStrength = 10f,
+            float warpFrequency = 0.01f)
+        {
+            _seed = seed;
+            _scale = Mathf.Max(1e-3f, scale);
+            _octaves = Mathf.Max(1, octaves);
+            _lacunarity = Mathf.Max(1.0f, lacunarity);
+            _gain = Mathf.Clamp01(gain);
+            _offset = offset;
+            _domainWarp = domainWarp;
+            _warpStrength = warpStrength;
+            _warpFrequency = Mathf.Max(1e-5f, warpFrequency);
+        }
+
+        public void Generate(float[] heights, int resolution, Vector2 worldOrigin, float worldSize, in HeightmapGenerationContext context)
+        {
+            if (heights == null || heights.Length != resolution * resolution)
+                throw new System.ArgumentException("heights length must be resolution*resolution");
+
+            // 0..res-1 を 0..1 に正規化 → worldOrigin/worldSize に射影
+            float inv = 1.0f / (resolution - 1);
+            float baseFreq = 1.0f / Mathf.Max(1e-3f, _scale);
+
+            // シードをオフセットに混ぜる（Perlinに直接seed不可のため）
+            float seedOffX = HashTo01(_seed) * 10000.0f;
+            float seedOffY = HashTo01(_seed * 397) * 10000.0f;
+
+            for (int y = 0; y < resolution; y++)
+            {
+                float vy = worldOrigin.y + (y * inv) * worldSize;
+                for (int x = 0; x < resolution; x++)
+                {
+                    float vx = worldOrigin.x + (x * inv) * worldSize;
+
+                    // Domain warp（任意）
+                    float wx = vx;
+                    float wy = vy;
+                    if (_domainWarp)
+                    {
+                        float qx = Perlin(wx * _warpFrequency + seedOffX, wy * _warpFrequency + seedOffY);
+                        float qy = Perlin((wx + 17.123f) * _warpFrequency + seedOffX, (wy - 9.87f) * _warpFrequency + seedOffY);
+                        wx += (qx - 0.5f) * 2f * _warpStrength;
+                        wy += (qy - 0.5f) * 2f * _warpStrength;
+                    }
+
+                    float h = FBM(wx, wy, baseFreq, _octaves, _lacunarity, _gain, seedOffX, seedOffY);
+                    heights[x + y * resolution] = Mathf.Clamp01(h);
+                }
+            }
+        }
+
+        private static float FBM(float wx, float wy, float baseFreq, int octaves, float lacunarity, float gain, float seedX, float seedY)
+        {
+            float amp = 1f;
+            float freq = baseFreq;
+            float sum = 0f;
+            float norm = 0f;
+            for (int i = 0; i < octaves; i++)
+            {
+                float n = Perlin(wx * freq + seedX, wy * freq + seedY); // 0..1
+                n = n * 2f - 1f; // -1..1
+                sum += n * amp;
+                norm += amp;
+                amp *= gain;
+                freq *= lacunarity;
+            }
+            if (norm < 1e-6f) return 0.5f;
+            float v = sum / (2f * norm) + 0.5f; // 正規化して 0..1
+            return Mathf.Clamp01(v);
+        }
+
+        private static float Perlin(float x, float y)
+        {
+            return Mathf.PerlinNoise(x, y);
+        }
+
+        private static float HashTo01(int v)
+        {
+            unchecked
+            {
+                uint x = (uint)v;
+                x ^= x >> 16;
+                x *= 0x7feb352d;
+                x ^= x >> 15;
+                x *= 0x846ca68b;
+                x ^= x >> 16;
+                return (x & 0xFFFFFF) / (float)0x1000000; // 0..1 未満
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/TerrainChunk.cs
+++ b/Assets/Scripts/Terrain/TerrainChunk.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using Vastcore.Terrain.Config;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Terrain
+{
+    /// <summary>
+    /// 1 チャンクの Terrain を生成・保持するコンポーネント。
+    /// </summary>
+    public sealed class TerrainChunk : MonoBehaviour
+    {
+        [SerializeField] private TerrainGenerationConfig _config;
+        [SerializeField] private Vector2 _worldOrigin;
+
+        public Terrain UnityTerrain { get; private set; }
+        public TerrainData TerrainData { get; private set; }
+
+        /// <summary>
+        /// コンフィグとプロバイダを用いて Terrain を生成します。
+        /// </summary>
+        public void Build(TerrainGenerationConfig config, IHeightmapProvider provider, Vector2 worldOrigin)
+        {
+            _config = config;
+            _worldOrigin = worldOrigin;
+            if (config == null) { Debug.LogError("TerrainChunk.Build: config is null"); return; }
+            if (provider == null) { Debug.LogError("TerrainChunk.Build: provider is null"); return; }
+
+            int res = Mathf.Max(2, config.resolution);
+            float size = Mathf.Max(1f, config.worldSize);
+            float heightScale = Mathf.Max(0.1f, config.heightScale);
+
+            // Generate normalized heights [0,1]
+            var heights = new float[res * res];
+            var ctx = new HeightmapGenerationContext { Seed = 0 }; // seed は settings 側で適用済み
+            provider.Generate(heights, res, worldOrigin, size, ctx);
+
+            // Unity Terrain expects heights in [0,1] but with 2D array [res,res]
+            var heights2D = new float[res, res];
+            for (int y = 0; y < res; y++)
+            {
+                for (int x = 0; x < res; x++)
+                {
+                    heights2D[y, x] = Mathf.Clamp01(heights[x + y * res]);
+                }
+            }
+
+            TerrainData = new TerrainData
+            {
+                heightmapResolution = res,
+            };
+            TerrainData.size = new Vector3(size, heightScale, size);
+            TerrainData.SetHeights(0, 0, heights2D);
+
+            var go = gameObject;
+            var terrain = go.GetComponent<Terrain>();
+            if (terrain == null) terrain = go.AddComponent<Terrain>();
+            terrain.terrainData = TerrainData;
+            terrain.drawInstanced = true;
+            UnityTerrain = terrain;
+        }
+
+        public static TerrainChunk CreateAndBuild(TerrainGenerationConfig config, IHeightmapProvider provider, Vector2 worldOrigin)
+        {
+            var go = new GameObject($"TerrainChunk_{worldOrigin.x}_{worldOrigin.y}");
+            var chunk = go.AddComponent<TerrainChunk>();
+            chunk.Build(config, provider, worldOrigin);
+            return chunk;
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/Terrain/TerrainProviderInjectionTests.cs
+++ b/Assets/Tests/PlayMode/Terrain/TerrainProviderInjectionTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using Vastcore.Terrain.Config;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Tests.PlayMode.Terrain
+{
+    public class TerrainProviderInjectionTests
+    {
+        private static NoiseHeightmapSettings CreateNoiseSettings(int seed = 12345)
+        {
+            var s = ScriptableObject.CreateInstance<NoiseHeightmapSettings>();
+            s.seed = seed;
+            s.scale = 200f;
+            s.octaves = 5;
+            s.lacunarity = 2.0f;
+            s.gain = 0.5f;
+            s.offset = Vector2.zero;
+            s.domainWarp = false;
+            return s;
+        }
+
+        [Test]
+        public void Provider_Reproducibility_SameSeed()
+        {
+            int res = 129;
+            float worldSize = 256f;
+            var origin = Vector2.zero;
+            var settings = CreateNoiseSettings(111);
+            var p1 = settings.CreateProvider();
+            var p2 = settings.CreateProvider();
+
+            var h1 = new float[res * res];
+            var h2 = new float[res * res];
+            var ctx = new HeightmapGenerationContext { Seed = 0 };
+            p1.Generate(h1, res, origin, worldSize, ctx);
+            p2.Generate(h2, res, origin, worldSize, ctx);
+
+            for (int i = 0; i < h1.Length; i++)
+            {
+                Assert.That(Mathf.Abs(h1[i] - h2[i]) < 1e-6f, $"Index {i} differs: {h1[i]} vs {h2[i]}");
+            }
+        }
+
+        [Test]
+        public void Provider_DifferentSeed_ProducesDifferent()
+        {
+            int res = 129;
+            float worldSize = 256f;
+            var origin = Vector2.zero;
+            var s1 = CreateNoiseSettings(111);
+            var s2 = CreateNoiseSettings(222);
+            var p1 = s1.CreateProvider();
+            var p2 = s2.CreateProvider();
+
+            var h1 = new float[res * res];
+            var h2 = new float[res * res];
+            var ctx = new HeightmapGenerationContext { Seed = 0 };
+            p1.Generate(h1, res, origin, worldSize, ctx);
+            p2.Generate(h2, res, origin, worldSize, ctx);
+
+            bool anyDiff = false;
+            for (int i = 0; i < h1.Length; i++)
+            {
+                if (Mathf.Abs(h1[i] - h2[i]) > 1e-4f) { anyDiff = true; break; }
+            }
+            Assert.IsTrue(anyDiff, "Different seeds should produce different height samples.");
+        }
+
+        [Test]
+        public void Provider_Seamless_On_Adjacent_Chunks()
+        {
+            int res = 129;
+            float worldSize = 256f;
+            var leftOrigin = Vector2.zero;
+            var rightOrigin = new Vector2(worldSize, 0f);
+            var settings = CreateNoiseSettings(333);
+            var provider = settings.CreateProvider();
+            var ctx = new HeightmapGenerationContext { Seed = 0 };
+
+            var left = new float[res * res];
+            var right = new float[res * res];
+            provider.Generate(left, res, leftOrigin, worldSize, ctx);
+            provider.Generate(right, res, rightOrigin, worldSize, ctx);
+
+            // 共有エッジ: 左の最右列(x=res-1) と 右の最左列(x=0) が一致
+            for (int y = 0; y < res; y++)
+            {
+                float l = left[(res - 1) + y * res];
+                float r = right[0 + y * res];
+                Assert.That(Mathf.Abs(l - r) < 1e-4f, $"Seam mismatch at y={y}: {l} vs {r}");
+            }
+        }
+
+        [Test]
+        public void TerrainChunk_Builds_From_Provider()
+        {
+            // ランタイム生成が例外なく完了し、TerrainData が設定されることを確認
+            var cfg = ScriptableObject.CreateInstance<TerrainGenerationConfig>();
+            cfg.heightmapSettings = CreateNoiseSettings(444);
+            cfg.resolution = 129;
+            cfg.worldSize = 256f;
+            cfg.heightScale = 80f;
+            var provider = cfg.CreateHeightProvider();
+
+            var chunk = new GameObject("TestChunk").AddComponent<Vastcore.Terrain.TerrainChunk>();
+            chunk.Build(cfg, provider, Vector2.zero);
+            Assert.IsNotNull(chunk.TerrainData);
+            Assert.IsNotNull(chunk.UnityTerrain);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/Vastcore.Tests.PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/Vastcore.Tests.PlayMode.asmdef
@@ -4,7 +4,8 @@
   "references": [
     "Vastcore.Core",
     "Vastcore.Player",
-    "Vastcore.UI"
+    "Vastcore.UI",
+    "Vastcore.Terrain"
   ],
   "includePlatforms": [],
   "excludePlatforms": [

--- a/docs/02_design/TERRAIN_ENGINE_DESIGN.md
+++ b/docs/02_design/TERRAIN_ENGINE_DESIGN.md
@@ -1,0 +1,55 @@
+# Terrain Engine Design (Phase 3 / M1)
+
+## 目的
+
+- シード駆動の再現性ある地形生成。
+- 高さデータ供給源を抽象化し、ノイズ/テクスチャ/ハイブリッドを差し替え可能にする。
+- M1ではノイズベースを実装。将来M4/M5以降でテクスチャ/ハイブリッドを容易に拡張。
+
+## アーキテクチャ概要
+
+- 名前空間: `Vastcore.Terrain`
+- コンポーネント:
+  - `IHeightmapProvider`: 高さデータ供給源の抽象。
+  - `NoiseHeightmapProvider`: ノイズによる高さ生成（M1）。
+  - `TerrainGenerationConfig` (`ScriptableObject`): プロバイダ設定/解像度/ワールドサイズ。
+  - `TerrainChunk`: プロバイダから高さグリッドを取得し、`Unity Terrain` を生成。
+
+```mermaid
+flowchart LR
+  Camera -->|視野/距離| StreamingController
+  StreamingController --> TerrainChunkPool
+  TerrainChunkPool --> TerrainChunk
+  TerrainChunk -->|Sample| IHeightmapProvider
+  IHeightmapProvider -->|Settings| TerrainGenerationConfig
+  TerrainChunk -->|Apply| UnityTerrainData
+```
+
+## 高さデータ供給の抽象化
+
+- インターフェース:
+  - `Generate(float[] heights, int resolution, Vector2 worldOrigin, float worldSize, HeightmapGenerationContext ctx)`
+  - 出力は正規化[0,1]。座標は `worldOrigin`/`worldSize` に基づくワールド一貫系。
+- 実装の例:
+  - `NoiseHeightmapProvider`（M1）
+  - `TextureHeightmapProvider`（将来）
+  - `HybridHeightmapProvider`（将来）
+- 設定は `ScriptableObject` ベースの多態で保持し、Factoryで `IHeightmapProvider` を供給。
+
+## M1 範囲（DoD）
+
+- 3×3 チャンクをノイズで生成し、例外無しで描画。
+- 同一seed/座標で再現性を確認。隣接チャンクの境界シーム差分は閾値以下。
+- PlayMode テスト（Provider差し替え/範囲/再現性/シーム）を追加しグリーン。
+
+## テスト観点
+
+- 再現性: 同seedで同一出力。
+- パラメータ: scale/octaves/gain/lacunarity/offset の影響が制御可能。
+- シーム: 隣接チャンクの共有エッジが一致。
+
+## 将来拡張（抜粋）
+
+- `TextureHeightmapProvider`: Texture2Dから高さをサンプル（UV→[0,1]）。
+- `HybridHeightmapProvider`: テクスチャ基盤+ノイズディテールの合成。
+- Jobs/Burst/Compute: 生成の並列化/高速化（M8）。


### PR DESCRIPTION
Add IHeightmapProvider abstraction, NoiseHeightmapProvider (FBM), TerrainGenerationConfig (SO), TerrainChunk (Unity Terrain build), PlayMode tests (repro/seam/range), and design doc. Closes #29.