### PR TITLE
docs(ui): A3-1 menus dry-run/result reports

### DIFF
--- a/AI_CONTEXT.md
+++ b/AI_CONTEXT.md
@@ -1,16 +1,15 @@
 # AI Context
- - 最終更新: 2025-10-05T20:33:26+09:00
- - 現在のミッション: フェーズ2: Sprint 02 [A3] 段階適用と検証（限定適用→ビルド/シーン動作確認→レポート反映）
- - ブランチ: feat/ui-migration-a3
- - 関連: Issue https://github.com/YuShimoji/VastCore/issues/17
- - 進捗: 20% / ステータス: 着手（適用ウィンドウ追加、ドキュ更新中）
- - 次の中断可能点: PR 作成後、CI 成功待ち
+- 最終更新: 2025-10-08T21:21:32+09:00
+- 現在のミッション: フェーズ2: Sprint 02 [A3] 段階適用と検証（限定適用→ビルド/シーン動作確認→レポート反映）
+- ブランチ: feat/ui-migration-a3-apply-menus
+- 関連: Issue https://github.com/YuShimoji/VastCore/issues/17
+- 進捗: 30% / ステータス: 着手（Menusスコープでプレビュー/適用確認、レポート更新）
+- 次の中断可能点: PR 作成後、CI 成功待ち
 ## 決定事項
 - 共有ワークフロー `ci-smoke.yml`/`sync-issues.yml` を再利用する。
 - Node の簡易 dev server / smoke check を本リポジトリに追加して CI 成功を保証。
 - 本プロジェクトの開発規約は中央ルールに準拠し、差分は `DEVELOPMENT_PROTOCOL.md` に記載。
 - gh CLI 非導入環境の場合の PR 自動化が難しい → 存在すれば自動、なければ手動 PR 案内。
-- CI が Node 依存のため Unity 専用の検証は別途導入が必要 → 将来の拡張項目に記載。
 
 ## Backlog（将来提案）
 - Unity Editor 用の headless smoke（起動/アセンブリスキャン）を Actions に追加。

--- a/Documentation/QA/UI_MIGRATION_APPLY_PREVIEW_MENUS.md
+++ b/Documentation/QA/UI_MIGRATION_APPLY_PREVIEW_MENUS.md
@@ -1,0 +1,18 @@
+# UI Migration Apply Preview - Menus (A3)
+
+- Generated: 2025-10-08 00:05 (local)
+- Rules Version: 1.0
+- Scope: `Assets/Scripts/UI/Menus/`
+
+## Findings
+- Files scanned: 1
+- Planned namespace replacements: 0
+- Planned class replacements: 0
+- CreateAssetMenu menuName updates: 0
+
+## Items
+- None (no changes required under `Assets/Scripts/UI/Menus/`).
+
+## Notes
+- Based on `docs/ui-migration/ui_mapping_rules.template.json`.
+- This is a dry preview; actual apply will create `.bak` backups per file if modifications occur.

--- a/Documentation/QA/UI_MIGRATION_APPLY_RESULT_MENUS.md
+++ b/Documentation/QA/UI_MIGRATION_APPLY_RESULT_MENUS.md
@@ -1,0 +1,17 @@
+# UI Migration Apply Result - Menus (A3)
+
+- Generated: 2025-10-08 21:21 (local)
+- Rules Version: 1.0
+- Scope: `Assets/Scripts/UI/Menus/`
+
+## Summary
+- Files processed: 1
+- Files changed: 0
+- Backups created: 0
+
+## Details
+- No modifications were required; existing code already conforms to the new `Vastcore.UI` namespace structure.
+
+## Verification
+- No code changes → no compile impact.
+- Unity Editor validation pending (run after other A3 scopes are applied).

--- a/docs/SPRINT_PLAN_02.md
+++ b/docs/SPRINT_PLAN_02.md
@@ -13,6 +13,7 @@
     - [A3] 段階適用と検証
       - 限定適用→ビルド/シーン動作確認→レポート反映
       - 状態: 着手済（`UIMigrationApplyWindow.cs` 追加、限定適用プレビュー・適用を実装）
+      - A3-1: `Assets/Scripts/UI/Menus/`（変更なし）→ `Documentation/QA/UI_MIGRATION_APPLY_PREVIEW_MENUS.md`, `UI_MIGRATION_APPLY_RESULT_MENUS.md` を更新
 
 - **管理**
   - 追跡: Issue #11（A1）, Issue #13（A2）, Issue #17（A3）


### PR DESCRIPTION
Sprint 02 [A3-1] Menus scope update.\n\nChanges:\n- Add Documentation/QA/UI_MIGRATION_APPLY_PREVIEW_MENUS.md\n- Add Documentation/QA/UI_MIGRATION_APPLY_RESULT_MENUS.md\n- Update docs/SPRINT_PLAN_02.md with A3-1 note\n- Update AI_CONTEXT.md (branch/ progress timestamp)\n\nNo code changes; documentation only.