### PR TITLE
feat(terrain): world streaming terrain chunks [closes #35]

### DIFF
--- a/Assets/Scripts/Terrain/TerrainChunkPool.cs
+++ b/Assets/Scripts/Terrain/TerrainChunkPool.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Vastcore.Terrain.Config;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Terrain
+{
+    /// <summary>
+    /// TerrainChunk をプールし再利用するシンプルなオブジェクトプール。
+    /// </summary>
+    public sealed class TerrainChunkPool : MonoBehaviour
+    {
+        [SerializeField] private TerrainGenerationConfig _config;
+
+        private readonly Stack<TerrainChunk> _pool = new Stack<TerrainChunk>();
+        private readonly HashSet<TerrainChunk> _active = new HashSet<TerrainChunk>();
+
+        private IHeightmapProvider _provider;
+        private int _totalCreated;
+
+        public TerrainGenerationConfig Config => _config;
+        public int TotalCreated => _totalCreated;
+        public int ActiveCount => _active.Count;
+        public IReadOnlyCollection<TerrainChunk> ActiveChunks => _active;
+
+        public void Initialize(TerrainGenerationConfig config)
+        {
+            _config = config;
+            ReleaseAll();
+            _provider = _config != null ? _config.CreateHeightProvider() : null;
+        }
+
+        public TerrainChunk Acquire(Vector2 worldOrigin, Transform parent = null)
+        {
+            if (_config == null || _provider == null)
+            {
+                Debug.LogError("TerrainChunkPool.Acquire called without config/provider");
+                return null;
+            }
+
+            TerrainChunk chunk;
+            if (_pool.Count > 0)
+            {
+                chunk = _pool.Pop();
+            }
+            else
+            {
+                var go = new GameObject("PooledTerrainChunk");
+                chunk = go.AddComponent<TerrainChunk>();
+                _totalCreated++;
+            }
+
+            var chunkTransform = chunk.transform;
+            chunkTransform.SetParent(parent != null ? parent : transform, false);
+            chunk.gameObject.SetActive(true);
+            chunk.Build(_config, _provider, worldOrigin);
+            _active.Add(chunk);
+            return chunk;
+        }
+
+        public void Release(TerrainChunk chunk)
+        {
+            if (chunk == null) return;
+            if (_active.Remove(chunk))
+            {
+                chunk.gameObject.SetActive(false);
+                chunk.transform.SetParent(transform, false);
+                _pool.Push(chunk);
+            }
+        }
+
+        public void ReleaseAll()
+        {
+            if (_active.Count == 0 && _pool.Count == 0) return;
+
+            foreach (var chunk in _active)
+            {
+                if (chunk == null) continue;
+                chunk.gameObject.SetActive(false);
+                chunk.transform.SetParent(transform, false);
+                _pool.Push(chunk);
+            }
+            _active.Clear();
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var chunk in _pool)
+            {
+                if (chunk != null)
+                {
+                    if (Application.isPlaying)
+                        Destroy(chunk.gameObject);
+                    else
+                        DestroyImmediate(chunk.gameObject);
+                }
+            }
+            _pool.Clear();
+            _active.Clear();
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/TerrainStreamingController.cs
+++ b/Assets/Scripts/Terrain/TerrainStreamingController.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Vastcore.Terrain.Config;
+
+namespace Vastcore.Terrain
+{
+    /// <summary>
+    /// カメラやターゲット位置に基づいてチャンクのストリーミングを制御するコンポーネント。
+    /// </summary>
+    public sealed class TerrainStreamingController : MonoBehaviour
+    {
+        [Header("Streaming Settings")]
+        public Transform target;
+        public TerrainGenerationConfig config;
+        [Min(0)] public int loadRadius = 1;
+        [Tooltip("チャンクのワールド原点。TerrainGenerationConfig.worldSize 単位で軸方向に増減する。")]
+        public Vector2 worldOrigin = Vector2.zero;
+        [Tooltip("ターゲット移動がこの距離を超えたらストリーミング判定を行う。")]
+        [Min(0.01f)] public float updateThreshold = 10f;
+        [Tooltip("1フレームで生成するチャンク数の上限。0 で制限なし。")]
+        [Min(0)] public int maxLoadPerFrame = 0;
+
+        private TerrainChunkPool _pool;
+        private readonly Dictionary<Vector2Int, TerrainChunk> _active = new Dictionary<Vector2Int, TerrainChunk>();
+
+        private Vector3 _lastTargetPos;
+        private Vector2Int _currentCenter;
+        private bool _initialized;
+
+        public IReadOnlyDictionary<Vector2Int, TerrainChunk> ActiveChunks => _active;
+        public Vector2Int CurrentCenter => _currentCenter;
+        public TerrainChunkPool Pool => _pool;
+
+        private void Awake()
+        {
+            EnsurePool();
+        }
+
+        private void Start()
+        {
+            if (target == null && Camera.main != null)
+            {
+                target = Camera.main.transform;
+            }
+
+            if (!_initialized)
+            {
+                Initialize();
+            }
+        }
+
+        private void Update()
+        {
+            if (!_initialized) return;
+            if (target == null) return;
+
+            var pos = target.position;
+            float dist = (pos - _lastTargetPos).sqrMagnitude;
+            if (dist >= updateThreshold * updateThreshold)
+            {
+                UpdateStreaming(pos);
+            }
+        }
+
+        public void Initialize()
+        {
+            if (config == null)
+            {
+                Debug.LogError("TerrainStreamingController: config is null");
+                return;
+            }
+
+            EnsurePool();
+
+            _pool.Initialize(config);
+            _active.Clear();
+            _initialized = true;
+
+            var pos = target != null ? target.position : transform.position;
+            UpdateStreaming(pos, force: true);
+        }
+
+        public void UpdateStreaming(Vector3 targetPosition, bool force = false)
+        {
+            if (!_initialized || config == null)
+                return;
+
+            float size = Mathf.Max(1f, config.worldSize);
+            Vector2 relative = new Vector2(targetPosition.x - worldOrigin.x, targetPosition.z - worldOrigin.y);
+            int cx = Mathf.FloorToInt(relative.x / size);
+            int cz = Mathf.FloorToInt(relative.y / size);
+            var newCenter = new Vector2Int(cx, cz);
+
+            if (!force && newCenter == _currentCenter)
+                return;
+
+            _currentCenter = newCenter;
+            _lastTargetPos = targetPosition;
+
+            var needed = new HashSet<Vector2Int>();
+            for (int dz = -loadRadius; dz <= loadRadius; dz++)
+            {
+                for (int dx = -loadRadius; dx <= loadRadius; dx++)
+                {
+                    needed.Add(new Vector2Int(cx + dx, cz + dz));
+                }
+            }
+
+            var toRelease = new List<Vector2Int>();
+            foreach (var kv in _active)
+            {
+                if (!needed.Contains(kv.Key))
+                {
+                    toRelease.Add(kv.Key);
+                }
+            }
+
+            foreach (var coord in toRelease)
+            {
+                _pool.Release(_active[coord]);
+                _active.Remove(coord);
+            }
+
+            int loadedThisFrame = 0;
+            foreach (var coord in needed)
+            {
+                if (_active.ContainsKey(coord))
+                    continue;
+
+                if (maxLoadPerFrame > 0 && loadedThisFrame >= maxLoadPerFrame)
+                    break;
+
+                Vector2 origin = new Vector2(worldOrigin.x + coord.x * size, worldOrigin.y + coord.y * size);
+                var chunk = _pool.Acquire(origin, transform);
+                if (chunk != null)
+                {
+                    _active.Add(coord, chunk);
+                    loadedThisFrame++;
+                }
+            }
+        }
+
+        public void ClearAll()
+        {
+            foreach (var kv in _active)
+            {
+                _pool.Release(kv.Value);
+            }
+            _active.Clear();
+        }
+
+        private void EnsurePool()
+        {
+            if (_pool == null)
+            {
+                _pool = GetComponent<TerrainChunkPool>();
+                if (_pool == null)
+                {
+                    _pool = gameObject.AddComponent<TerrainChunkPool>();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/Terrain/TerrainStreamingTests.cs
+++ b/Assets/Tests/PlayMode/Terrain/TerrainStreamingTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using Vastcore.Terrain;
+using Vastcore.Terrain.Config;
+using Vastcore.Terrain.Providers;
+
+namespace Vastcore.Tests.PlayMode.Terrain
+{
+    public class TerrainStreamingTests
+    {
+        private const int DefaultRadius = 1;
+
+        private static TerrainGenerationConfig CreateConfig(float constantHeight = 0.35f)
+        {
+            var config = ScriptableObject.CreateInstance<TerrainGenerationConfig>();
+            var settings = ScriptableObject.CreateInstance<ConstantHeightmapSettings>();
+            settings.constantValue = constantHeight;
+            config.heightmapSettings = settings;
+            config.resolution = 33;
+            config.worldSize = 64f;
+            config.heightScale = 40f;
+            return config;
+        }
+
+        private static TerrainStreamingController CreateController(int radius = DefaultRadius)
+        {
+            var go = new GameObject("TerrainStreamingController_Test");
+            var controller = go.AddComponent<TerrainStreamingController>();
+            controller.config = CreateConfig();
+            controller.loadRadius = radius;
+            controller.target = go.transform; // 自身を基準に移動検証
+            controller.updateThreshold = 0.1f; // テストで容易に更新
+            controller.maxLoadPerFrame = 0;
+            controller.worldOrigin = Vector2.zero;
+            controller.Initialize();
+            return controller;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var controller in Object.FindObjectsOfType<TerrainStreamingController>())
+            {
+                controller.ClearAll();
+                Object.DestroyImmediate(controller.gameObject);
+            }
+        }
+
+        [Test]
+        public void StreamingLoadsInitialRadius()
+        {
+            var controller = CreateController();
+            int expected = Mathf.Pow((DefaultRadius * 2) + 1, 2);
+            Assert.AreEqual(expected, controller.ActiveChunks.Count, "Initial active chunk count mismatch");
+            Assert.AreEqual(expected, controller.Pool.ActiveCount, "Pool active count mismatch");
+            Assert.AreEqual(expected, controller.Pool.TotalCreated, "Unexpected number of created chunks");
+        }
+
+        [Test]
+        public void StreamingReactsToMovement()
+        {
+            var controller = CreateController();
+            float moveDist = controller.config.worldSize * 1.1f;
+            controller.UpdateStreaming(new Vector3(moveDist, 0f, 0f));
+
+            Assert.AreEqual(new Vector2Int(1, 0), controller.CurrentCenter, "Center should shift by one chunk on X axis");
+            int expected = Mathf.Pow((DefaultRadius * 2) + 1, 2);
+            Assert.AreEqual(expected, controller.ActiveChunks.Count, "Active chunk count should remain constant after move");
+        }
+
+        [Test]
+        public void PoolReusesChunksWhenMovingBackAndForth()
+        {
+            var controller = CreateController();
+            int expected = Mathf.Pow((DefaultRadius * 2) + 1, 2);
+            int initialCreated = controller.Pool.TotalCreated;
+            Assert.AreEqual(expected, initialCreated, "Initial created chunks should match required ring");
+
+            float size = controller.config.worldSize;
+            controller.UpdateStreaming(new Vector3(size * 1.2f, 0f, 0f)); // move +X
+            controller.UpdateStreaming(new Vector3(0f, 0f, size * 1.2f)); // move +Z
+            controller.UpdateStreaming(Vector3.zero); // back to origin
+
+            Assert.AreEqual(expected, controller.ActiveChunks.Count, "Active chunk count should remain constant after moves");
+            Assert.AreEqual(initialCreated, controller.Pool.TotalCreated, "Pool should reuse chunks instead of creating new ones");
+        }
+
+        #region Helpers
+
+        private sealed class ConstantHeightmapSettings : HeightmapProviderSettings
+        {
+            public float constantValue = 0.5f;
+
+            public override IHeightmapProvider CreateProvider()
+            {
+                return new ConstantHeightmapProvider(Mathf.Clamp01(constantValue));
+            }
+        }
+
+        private sealed class ConstantHeightmapProvider : IHeightmapProvider
+        {
+            private readonly float _value;
+
+            public ConstantHeightmapProvider(float value)
+            {
+                _value = Mathf.Clamp01(value);
+            }
+
+            public void Generate(float[] heights, int resolution, Vector2 worldOrigin, float worldSize, in HeightmapGenerationContext context)
+            {
+                if (heights == null || heights.Length != resolution * resolution)
+                {
+                    throw new System.ArgumentException("Invalid height array");
+                }
+
+                for (int i = 0; i < heights.Length; i++)
+                {
+                    heights[i] = _value;
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/docs/02_design/TERRAIN_ENGINE_DESIGN.md
+++ b/docs/02_design/TERRAIN_ENGINE_DESIGN.md
@@ -53,3 +53,45 @@ flowchart LR
 - `TextureHeightmapProvider`: Texture2Dから高さをサンプル（UV→[0,1]）。
 - `HybridHeightmapProvider`: テクスチャ基盤+ノイズディテールの合成。
 - Jobs/Burst/Compute: 生成の並列化/高速化（M8）。
+
+## M2: World Streaming（チャンク生成/破棄）
+
+### スコープ
+
+- カメラ（または任意ターゲット）位置を中心に、リング半径 `loadRadius` 内のチャンクを自動生成。
+- 範囲外のチャンクはプールへ返却し再利用。生成スパイクを抑制。
+- `TerrainGenerationConfig` + `IHeightmapProvider` を継続利用し、差し替え可能な高さソースを維持。
+
+### 主要コンポーネント
+
+- `TerrainChunkPool`
+  - `Stack<TerrainChunk>` によるシンプルなプール。
+  - `Get(origin)` でアクティブ化＆再ビルド、`Release(chunk)` で非アクティブ化。
+  - 将来の非同期生成やバッチ生成へ拡張可能。
+- `TerrainStreamingController`
+  - フォーカスターゲット（デフォルト `Camera.main`）を追跡し、ワールド座標→チャンク座標へ変換。
+  - `UpdateStreaming(position)` で必要チャンク集合を算出し、差分ロード/アンロード。
+  - `ActiveChunkCoords`（読み取り専用）と `CurrentCenter` を公開（テスト・可視化用）。
+  - `loadRadius`, `worldOrigin`, `updateThreshold`, `maxLoadPerFrame` 等を設定可能。
+
+### 実装方針
+
+- チャンク座標: `Vector2Int(cx, cz)`、ワールド原点とチャンクサイズ(`worldSize`)から `origin = worldOrigin + (cx * worldSize, cz * worldSize)` を算出。
+- 更新頻度: ターゲットの移動距離が `updateThreshold` を越えた際にのみ差分計算。
+- 破棄タイミング: 必要集合から外れたチャンクは即座に `Release()` し、プールへ格納。
+- 拡張余地: `maxLoadPerFrame` で生成件数を制限しスパイクを抑制（M2では閾値小・必要なら次フェーズで最適化）。
+
+### DoD（完了条件）
+
+- 半径 `loadRadius` に応じた `(2r+1)^2` 枚のチャンクが常にアクティブ。
+- ターゲット移動で新たなチャンクが生成され、遠方チャンクはプールへ戻る。
+- `TerrainChunkPool` による再利用が確認でき、GC/生成スパイクが抑制される（ログまたはプロファイラでヒッチ<20ms 目標）。
+- PlayMode テスト（`TerrainStreamingTests`）が再現性とシームレス性を担保。
+
+### テスト計画
+
+- **StreamingLoadsInitialRadius**: 初回 `UpdateStreaming` 後に `(2r+1)^2` チャンクが生成されること。
+- **StreamingReactsToMovement**: チャンク1枚分以上移動した際、中心座標が更新され、古いチャンクがアンロードされること。
+- **PoolReusesChunks**: チャンクをアンロード後に再び必要になった際、プールが再利用される（生成回数が増えない）。
+
+PlayMode テストでは `HeightmapProviderSettings` をテスト用に派生させ、一定高さを返すプロバイダで挙動を検証する。


### PR DESCRIPTION
## Summary
- add TerrainChunkPool to reuse terrain chunks instead of destroying them
- add TerrainStreamingController to maintain active chunk ring based on target position
- add PlayMode tests (streaming load, movement reaction, pool reuse)
- update design doc docs/02_design/TERRAIN_ENGINE_DESIGN.md with M2 scope/DoD/test plan

## Testing
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-tests.ps1 -TestMode playmode (fails: existing errors in PrimitiveTerrain*)