### PR TITLE
chore: outcome-based AI workflow and Project Pulse

### DIFF
--- a/.github/workflows/project-pulse.yml
+++ b/.github/workflows/project-pulse.yml
@@ -1,0 +1,140 @@
+name: Project State and Pulse
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+      - "feature/**"
+    paths:
+      - docs/runtime-state.md
+      - docs/REPO_LOCAL_RULES.md
+      - docs/INVARIANTS.md
+      - docs/USER_REQUEST_LEDGER.md
+      - docs/OPERATOR_WORKFLOW.md
+      - docs/INTERACTION_NOTES.md
+      - docs/project-context.md
+      - docs/ai/**
+      - scripts/check-project-state.ps1
+      - .github/workflows/project-pulse.yml
+  pull_request:
+    paths:
+      - docs/runtime-state.md
+      - docs/REPO_LOCAL_RULES.md
+      - docs/INVARIANTS.md
+      - docs/USER_REQUEST_LEDGER.md
+      - docs/OPERATOR_WORKFLOW.md
+      - docs/INTERACTION_NOTES.md
+      - docs/project-context.md
+      - docs/ai/**
+      - scripts/check-project-state.ps1
+      - .github/workflows/project-pulse.yml
+  schedule:
+    - cron: "17 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: vastcore-project-state-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate canonical state
+        shell: pwsh
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
+          PULSE_BRANCH: ${{ vars.PROJECT_PULSE_BRANCH }}
+        run: |
+          $expected = if ($env:SOURCE_BRANCH -eq $env:PULSE_BRANCH) { $env:SOURCE_BRANCH } else { '' }
+          ./scripts/check-project-state.ps1 -ExpectedBranch $expected
+
+  publish:
+    if: github.event_name != 'pull_request' && github.ref_name == vars.PROJECT_PULSE_BRANCH
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Project Pulse issue
+        uses: actions/github-script@v7
+        env:
+          PROJECT_PULSE_ISSUE: ${{ vars.PROJECT_PULSE_ISSUE }}
+          PROJECT_PULSE_BRANCH: ${{ vars.PROJECT_PULSE_BRANCH }}
+          SOURCE_PATH: docs/runtime-state.md
+        with:
+          script: |
+            const fs = require('fs');
+            const title = '[Project Pulse] VastCore 現在地';
+            const marker = '<!-- vastcore-project-pulse -->';
+            const sourcePath = process.env.SOURCE_PATH;
+            const pulseBranch = process.env.PROJECT_PULSE_BRANCH;
+            const sourceBranch = context.ref.replace('refs/heads/', '');
+            if (!pulseBranch || sourceBranch !== pulseBranch) {
+              core.setFailed(`Refusing to publish from '${sourceBranch}'; Project Pulse owner is '${pulseBranch || 'unset'}'.`);
+              return;
+            }
+            const state = fs.readFileSync(sourcePath, 'utf8').trim();
+            const shortSha = context.sha.slice(0, 7);
+            const sourceUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.sha}/${sourcePath}`;
+            const dateMatch = state.match(/^Last Updated:\s*(\d{4}-\d{2}-\d{2})\s*$/m);
+            let staleWarning = '';
+
+            if (dateMatch) {
+              const ageDays = Math.floor((Date.now() - Date.parse(`${dateMatch[1]}T00:00:00Z`)) / 86400000);
+              if (ageDays > 7) {
+                staleWarning = `\n> [!WARNING]\n> 正本の最終更新から ${ageDays} 日経過しています。現在地を再確認してください。\n`;
+              }
+            }
+
+            const body = [
+              marker,
+              '> [!NOTE]',
+              '> このIssueは `docs/runtime-state.md` から自動生成されます。本文を直接編集しないでください。',
+              `> Source: [${sourceBranch}@${shortSha}](${sourceUrl}) · synced ${new Date().toISOString()}`,
+              staleWarning,
+              state,
+              '',
+              '---',
+              '判断やレビューはコメントへ残し、確定事項はリポジトリの owning document に反映します。'
+            ].filter(Boolean).join('\n');
+
+            const issueNumber = Number.parseInt(process.env.PROJECT_PULSE_ISSUE || '', 10);
+            if (!Number.isInteger(issueNumber)) {
+              core.setFailed('PROJECT_PULSE_ISSUE must name the pre-initialized Project Pulse issue.');
+              return;
+            }
+
+            const response = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            const issue = response.data;
+            const labels = issue.labels.map(label => typeof label === 'string' ? label : label.name);
+
+            if (issue.pull_request || issue.title !== title || !issue.body?.includes(marker) || !labels.includes('project-pulse')) {
+              core.setFailed(`Issue #${issueNumber} is not the initialized Project Pulse target.`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              title,
+              body,
+              state: 'open'
+            });
+
+            core.notice(`Project Pulse issue: #${issueNumber}`);

--- a/.github/workflows/project-pulse.yml
+++ b/.github/workflows/project-pulse.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate canonical state
         shell: pwsh
@@ -64,10 +64,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update Project Pulse issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PROJECT_PULSE_ISSUE: ${{ vars.PROJECT_PULSE_ISSUE }}
           PROJECT_PULSE_BRANCH: ${{ vars.PROJECT_PULSE_BRANCH }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -5,21 +5,40 @@ on:
   workflow_dispatch:
 
 jobs:
+  license-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - name: Check Unity license
+        id: check
+        shell: bash
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -n "$UNITY_LICENSE" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Unity tests not run::UNITY_LICENSE is not configured for this repository."
+          fi
+
   unity-tests:
-    if: ${{ secrets.UNITY_LICENSE != '' }}
+    needs: license-gate
+    if: needs.license-gate.outputs.available == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         testMode: [editmode, playmode]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run Unity ${{ matrix.testMode }} tests
         uses: game-ci/unity-test-runner@v4
         with:
           projectPath: .
-          unityVersion: 6000.2.2f1
+          unityVersion: 6000.3.6f1
           testMode: ${{ matrix.testMode }}
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
+++ b/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
@@ -86,7 +86,13 @@ Issue は通知、履歴、コメントによる判断回収に向き、`GITHUB_
 [#29082183177](https://github.com/YuShimoji/VastCore/actions/runs/29082183177) では、
 canonical state検証とIssue #48へのpublishがともに成功した。そこで検出された旧Node
 runtime警告は、公式release上の現行majorである `actions/checkout@v7` と
-`actions/github-script@v9` へ更新して解消する。
+`actions/github-script@v9` へ更新し、再実行
+[#29083404696](https://github.com/YuShimoji/VastCore/actions/runs/29083404696) の
+validate/publish成功で解消を確認した。
+
+現在の差分レビューはdraft PR
+[#49](https://github.com/YuShimoji/VastCore/pull/49) に限定している。baseは古いdefault
+`master` ではなく、直前のCockpit UX枝なので、運用差分だけを独立して判断できる。
 
 Wiki は今後、用語集、長期設計、確定した意思決定など更新頻度の低い読み物へ使う。
 視覚的ダッシュボードが必要になった時は、同じ正本から GitHub Pages を生成し、
@@ -111,7 +117,9 @@ Pulse本文の手動コピーは行わない。
 `if` から直接参照する無効なgateと、プロジェクトと異なるEditor versionを修正し、
 license-gateのboolean output経由でテストjobをskipできる構造にした。Editor指定も
 6000.3.6f1へ合わせた。repositoryに `UNITY_LICENSE` は未設定なので、これはworkflowを
-有効化する修正であり、Unityテスト成功の証拠ではない。
+有効化する修正であり、Unityテスト成功の証拠ではない。手動dispatch
+[#29083435552](https://github.com/YuShimoji/VastCore/actions/runs/29083435552) では
+license-gateが成功し、Unity test jobが意図どおり `skipped` になることを確認した。
 
 既存の `markdownlint` / CodeQL が `develop` のみを対象とする問題と、`main` 切替後の
 branch protection/CI全体設計は別スライスに残した。「赤いcheckを増やす」のではなく、

--- a/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
+++ b/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
@@ -1,0 +1,137 @@
+# VastCore AI Collaboration Workflow Refresh — 2026-07-10
+
+## 何を整えたか
+
+VastCore の最新成果を含む `fd1cb29` を統合基準として保持し、その上に
+`codex/vc-ai-workflow-refresh-20260710` を作成した。Git の同期は完了している。
+一方、Unity バッチ検証は既知の Package Manager 障害で C# コンパイル前に止まり、
+Designer Cockpit の Editor 手動受入も未実施である。したがって現在は
+「Git/編集は再開可能、Unity acceptance は未成立」と分けて扱う。
+
+今回の運用変更は、新しい手順書を増やすことではなく、既存の正本に不足していた
+実行契約を入れることに絞った。監修AIは一つの reviewable outcome を Mission Packet
+として渡し、開発AIはその範囲で実装、関連修正、検証、状態同期、commit/push まで
+止まらずに進める。高コストなUI・ビジュアル・コンテンツ変更だけは、2〜3方向を
+比較して intent を固定し、小さな proof slice を見てから横展開する。
+
+## リモート同期と開発可能性
+
+| 確認対象 | 実測 | 現在の判断 |
+|---|---|---|
+| 現行統合基準 | `codex/vc-rst-cockpit-ux-diagnostics-20260706` の `fd1cb29` | `origin` と 0 ahead / 0 behind。リモート上の最新成果を取得済み |
+| `origin/main` | `39f790c` | 現行基準の直系祖先で14コミット後方。ローカル `main` はここまで fast-forward 済み |
+| GitHub default | `master` の `23319f7` | 現行より349コミット後方。GitHub入口を最新と誤認させるため、受入後に `main` へ変更が必要 |
+| 分岐handoff枝 | `origin/codex/vc-rst-remote-handoff-20260622` | Packages/ProjectSettings/大量削除を混在した保存コミット。wholesale merge しない |
+| 作業ツリー | clean から専用枝を作成 | stash 5件と別 worktree 2件は触らず保全 |
+| Unity toolchain | 6000.3.6f1 導入済み | ソース編集と狭い静的検証は可能 |
+| Unity batch compile | `scripts/check-compile.ps1` exit 1 | `path undefined / No packages loaded`。C#診断には到達していない |
+| Cockpit acceptance | checklist と実装は存在 | Editor のレイアウト、Apply/Undo、save/load は手動確認待ち |
+
+## なぜ従来運用が減速したか
+
+履歴上も、2026-06-23から07-07までの14コミット中11件が docs-only の
+handoff/decisionで、06-25から06-29だけでもUPM関連のdocs-only commitが10件ある。
+安全診断と引継ぎが製品artifactより細かく分割され、主作業化していたことを示している。
+
+| 摩擦 | 構造原因 | 今回入れた補正 | 期待する変化 |
+|---|---|---|---|
+| 安全側へ倒れ続ける | Value、frontier、actor、approval の例外gateは多いが、可逆な通常判断を進める autonomy がなかった | ゲートを例外フィルタと定義し、停止を破壊的変更、依存/DB/認証/API契約、仕様衝突、未確定の高コスト方向へ限定 | 「念のため確認」では止まらず、具体的な危険と意思決定がある時だけ止まる |
+| Prompt が細切れになる | 旧 worker prompt 群を削除した後、監修→開発の代替パケットがなかった | Outcome、Why now、Scope、Acceptance、Autonomy、Stop、Creative checkpoint、Sync を一つの Mission Packet に集約 | 1 Prompt が1コマンドではなく1成果単位になり、関連修正と検証を連続実行できる |
+| 進捗と次作業が流れる | chat、restart report、古い index に状態が分散し、更新条件が通常読まない深いルールに隠れていた | branch/artifact/bottleneck/evidence/next action の変化時は `runtime-state` 更新を完了条件に昇格 | 次のAIが3ファイルで再開でき、Git同期・検証・人間受入を混同しない |
+| Wiki等が更新されない | Wiki/Pages/Issue の自動投影がなく、手作業の二重SSOTしか選べなかった | `runtime-state` を検証し、固定 GitHub Project Pulse Issue へ自動投影する workflow を追加 | 外部から一画面で現在地を確認でき、更新作業を思い出す必要がなくなる |
+| 創造提案がなく微修正沼になる | creative judgement をユーザー所有としただけで、AIの方向案提示と実装前checkpointがなかった | 高コスト変更は2〜3方向→intent固定→proof slice→batch review。2巡で収束しなければ原則へ戻る | 大きな成果物の後で意図を発見するのではなく、安い段階で方向を合わせられる |
+
+## 監修AIと開発AIの新しい分担
+
+監修AIは「何を達成するか」「なぜ今か」「どの方向を試すか」「本当に止める境界は
+何か」を担当する。開発AIは、その成果単位の内側にある実装順、関連する狭い修正、
+検証方法、正本同期を担当する。監修AIがコマンド列を作り、開発AIが一行ずつ消化する
+関係には戻さない。
+
+次回以降のPromptは `docs/OPERATOR_WORKFLOW.md` の Mission Packet をそのまま使用する。
+最低限、次の意味が一つのPrompt内で閉じていなければ発行しない。
+
+```text
+Outcome: 完了時に何が使える・判断できるようになるか
+Why now: 解消する現在の bottleneck
+Scope: coherent batch の境界と非対象
+Acceptance: 機械検証、人間確認、成果物の必要証拠
+Risk tier: routine / boundary-changing。後者だけ具体的な危険と判断を記述
+Autonomy: outcome 内の実装・関連修正・検証・状態同期・commit/push
+Stop only if: 具体的な破壊/契約/仕様衝突、または未選択の高コスト方向
+Creative checkpoint: 不要、方向案提示、または選択済み proof slice
+Start from / Sync on close: commit と正本パス
+```
+
+進捗はコマンドの実況ではなく、方針変更、reviewable な中間成果、長いツール待ちで
+共有する。完了時の次案は Advance / Verify / Excise / Explore のように異なる
+bottleneck を解き、各案で何が可能になるかを示す。
+
+## 外部から見える現在地
+
+ライブ状態に Wiki を選ばなかった理由は、Wiki が別リポジトリで手動更新と認証を
+増やし、再び二重SSOTになりやすいためである。固定・pin した GitHub Issue
+[#48 Project Pulse](https://github.com/YuShimoji/VastCore/issues/48) を作成し、
+`docs/runtime-state.md` を本文へ自動投影する。
+Issue は通知、履歴、コメントによる判断回収に向き、`GITHUB_TOKEN` の
+`issues: write` だけで更新できる。
+
+並行枝による後勝ち上書きを防ぐため、repository variable
+`PROJECT_PULSE_BRANCH` が公開元を一枝だけ指定する。作業枝を `main` へ昇格する時は、
+まずmerge自体を検証し、その後 `main` 上の `runtime-state` と同variableを同じhandoffで
+切り替える。これにより同一commitの昇格をbranch名検査で妨げず、未受入枝もPulseを
+奪えない。
+
+Wiki は今後、用語集、長期設計、確定した意思決定など更新頻度の低い読み物へ使う。
+視覚的ダッシュボードが必要になった時は、同じ正本から GitHub Pages を生成し、
+Pulse本文の手動コピーは行わない。
+
+外部公開の完全な正常化には、Cockpit成果の受入後に次の順番が必要になる。
+
+1. 現在のCockpit/運用枝をレビューし、受入済みtipを `main` へ fast-forwardする。
+2. GitHub default branch を古い `master` から `main` へ変更する。
+3. branch protection と Actions の対象を `main` に揃える。
+4. `master`、競合中の旧draft PR、古いstatus/indexを整理する。
+
+## 今回あえて混ぜなかった整理
+
+`docs/WORKFLOW_STATE_SSOT.md`、`docs/DOCS_INDEX.md`、`docs/HANDOVER.md`、大量の
+`docs/restart/` は、現在の3ファイル導線と重複または歴史化している。ただし一括削除は
+参照切れと証拠喪失を起こし得るため、今回の運用契約と混ぜていない。次の Excise
+スライスでは参照graphを検査し、current owner へ必要情報を昇格してから archive/delete
+を分けて実施する。
+
+同様に、既存の `markdownlint` / CodeQL は `develop` のみを対象とし、Unity workflow
+はプロジェクトと異なる Editor version を指定している。これらは「赤いcheckを増やす」
+ためではなく、`main` 切替と一緒に実行可能な最小CIへ直すべきで、今回の文書契約とは
+別スライスに残した。
+
+## Cockpitで先に比較する創造方向
+
+新しいcheckpointを実際に適用するなら、現行Cockpitをすぐ微修正せず、次の3方向から
+選ぶ。いずれも同じ画面の色違いではなく、誰のどの作業を中心にするかが異なる。
+
+| 方向 | 体験とレイアウト | 色・書体・motion | 言語と隣接コンテンツ | 最初のproof slice |
+|---|---|---|---|---|
+| **A. Operations Console** | 上部に状態/警告/証拠、中央にmode作業、右にDiagnostics。反復検証を最短化する高密度console | charcoal + terrain amber + verified green。本文は可読性優先、seed/値だけmono。状態遷移は短いfade/pulse | 日英併記はtooltipから開始。Evidence Tiles、check履歴、before/after snapshotへ伸ばす | Overview + Diagnosticsを一画面で再構成し、Cockpit smokeの証拠をその場で残す |
+| **B. Generative Atelier** | SceneView/previewを主役にし、Cockpitはrecipeとvariationを選ぶ細いdock。比較と偶発性を重視 | earth/cyanの低彩度palette、太いdisplay見出し。variation適用時にghost previewと差分motion | Recipe Library、seed history、Architecture/Biome kit、favorite比較へ伸ばす | Random Variation だけをnon-destructive preview + 3候補比較にする |
+| **C. Guided Forge** | Create→Shape→Compose→Verifyのstep rail。初心者が次の一手を失わない段階開示 | 明るいneutral base + mode固有accent。説明用sans、数値はtabular。完了時だけ穏やかなprogress motion | 日本語/英語切替を最初から想定し、用語集、例付きpreset、context helpへ伸ばす | Session作成からsave/loadまでを1本のguided flowにする |
+
+現時点の推奨は **Aを最初のproof slice** にすること。現在のacceptance bottleneckが
+Diagnosticsと手動smokeの可視化だからで、既存mode構造を壊さず実物から判断できる。
+その後、Bのpreview/recipeを創造レーン、Cの日英guidanceを導入レーンとして足す余地が
+ある。ただしA+B+Cの一括実装はせず、現行スクリーンショットを見て選択・混合してから
+着手する。
+
+## 次に開く入口
+
+| 入口 | 解く摩擦 | 必要条件と現在状態 | 完了すると可能になること |
+|---|---|---|---|
+| **Verify — Cockpit proof**（推奨） | 製品成果の受入が文書だけで止まっている | UPM障害を避けてEditorを開ける環境、または環境修復後。手動checklistは準備済み | workflow改善が製品進捗へ戻り、Cockpit枝を `main` 候補として判断できる |
+| **Advance — GitHub baseline** | default `master` と競合PRが外部現在地を壊す | Cockpit/運用枝のレビュー受入 | `main` を唯一の統合基準にし、Pulse・Actions・READMEを正しく動かせる |
+| **Excise — SSOT reduction** | 古いSSOT、handoff、indexが再開時のノイズになる | 参照graph監査とarchive方針。大規模削除は未実施 | 読む文書と更新ownerが減り、監修/開発双方のcontext負荷が下がる |
+| **Explore — Cockpit visual directions** | layout、i18n、type/color/motion、隣接コンテンツの提案不足 | 現行画面のスクリーンショットまたはEditor観測 | 2〜3方向を比較して次のproof sliceを選べ、完成後の微修正沼を避けられる |
+
+現時点の推奨は Verify である。ただし Unity/UPM がEditor起動自体を妨げる場合は、
+その事実を一度で切り分けて Advance または環境修復へ切り替え、再び長い安全診断を
+主作業にはしない。

--- a/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
+++ b/docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md
@@ -82,6 +82,12 @@ Issue は通知、履歴、コメントによる判断回収に向き、`GITHUB_
 切り替える。これにより同一commitの昇格をbranch名検査で妨げず、未受入枝もPulseを
 奪えない。
 
+初回GitHub Actions
+[#29082183177](https://github.com/YuShimoji/VastCore/actions/runs/29082183177) では、
+canonical state検証とIssue #48へのpublishがともに成功した。そこで検出された旧Node
+runtime警告は、公式release上の現行majorである `actions/checkout@v7` と
+`actions/github-script@v9` へ更新して解消する。
+
 Wiki は今後、用語集、長期設計、確定した意思決定など更新頻度の低い読み物へ使う。
 視覚的ダッシュボードが必要になった時は、同じ正本から GitHub Pages を生成し、
 Pulse本文の手動コピーは行わない。
@@ -101,10 +107,15 @@ Pulse本文の手動コピーは行わない。
 スライスでは参照graphを検査し、current owner へ必要情報を昇格してから archive/delete
 を分けて実施する。
 
-同様に、既存の `markdownlint` / CodeQL は `develop` のみを対象とし、Unity workflow
-はプロジェクトと異なる Editor version を指定している。これらは「赤いcheckを増やす」
-ためではなく、`main` 切替と一緒に実行可能な最小CIへ直すべきで、今回の文書契約とは
-別スライスに残した。
+同じ初回pushでは、既存 `unity-tests.yml` がjob開始前に即失敗した。secretをjob-level
+`if` から直接参照する無効なgateと、プロジェクトと異なるEditor versionを修正し、
+license-gateのboolean output経由でテストjobをskipできる構造にした。Editor指定も
+6000.3.6f1へ合わせた。repositoryに `UNITY_LICENSE` は未設定なので、これはworkflowを
+有効化する修正であり、Unityテスト成功の証拠ではない。
+
+既存の `markdownlint` / CodeQL が `develop` のみを対象とする問題と、`main` 切替後の
+branch protection/CI全体設計は別スライスに残した。「赤いcheckを増やす」のではなく、
+実行可能な検証だけを意味の分かる状態で表示するためである。
 
 ## Cockpitで先に比較する創造方向
 

--- a/docs/INTERACTION_NOTES.md
+++ b/docs/INTERACTION_NOTES.md
@@ -11,6 +11,18 @@ style.
 - Do not use fixed closeout templates unless the user asks for a fixed format.
 - When reporting residual work, include purpose, effect, requirements, current
   state, owner, and next move.
+- Keep Git sync, mechanical validation, and human/visual acceptance as separate
+  claims. A clean branch or written checklist is not Unity acceptance.
+
+## Progress Rhythm
+
+- Report a meaningful change in direction, a reviewable intermediate result, or
+  a long-running tool wait; do not narrate every command.
+- Close one coherent outcome with what changed, why it changes the workflow or
+  decision, evidence, uncertainty, and two to four genuinely different next
+  entrances when a choice is useful.
+- Mark one recommended default. Explain what becomes possible after each option,
+  rather than asking the user to choose an implementation procedure.
 
 ## Manual Verification Asks
 
@@ -19,6 +31,8 @@ style.
 - Use `OK / NG` or `PASS / FAIL` only after the target, actor, owner artifact,
   and success meaning are explicit.
 - Ask for next direction separately from manual verification.
+- Group related Editor checks into one batch. Do not return with a new manual ask
+  after every small fix.
 
 ## Avoid
 
@@ -26,10 +40,9 @@ style.
 - Options whose only axis is commit / do not commit.
 - Large markdown tables for short asks.
 - Reporting historical handoff text as if it were current evidence.
+- Safety language without a named hazard, consequence, and decision.
+- Micro-prompts for work that remains inside an approved outcome.
+- Broad visual implementation before direction intent is established.
 
-## Current User Preference Notes
-
-- The user asked for a strong modernization of VastCore project-local Agent
-  instructions, aligned with newer projects such as NLMYTGen.
-- `AGENTS.md` must remain thin and must not become procedures, status, roadmap,
-  closeout template, or history.
+Durable user preferences belong in `docs/USER_REQUEST_LEDGER.md`; this file owns
+only interaction behavior.

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,10 +1,11 @@
 # Invariants
 
-VastCore の非交渉条件・責務境界・禁止ショートカットを保持する正本。
+VastCore の非交渉条件、責任境界、禁止ショートカットを保持する正本。
 
 ## Product Invariants
 
-- 目的関数は「広大な景観に映える、ユニークで巨大な人工構造物をプロシージャルに生成する」こと。
+- 目的関数は「広大な景観に映える、ユニークで巨大な人工構造物を
+  プロシージャルに生成する」こと。
 - 現行の主軸は DualGrid + HeightMap + designer Prefab Stamp placement。
 - 3D Voxel / Marching Cubes を主経路へ戻すには、ユーザーの明示的な再承認が必要。
 - Marching Squares を主経路へ戻すには、Prefab Stamp 方針との衝突を先に解決する。
@@ -13,25 +14,28 @@ VastCore の非交渉条件・責務境界・禁止ショートカットを保�
 
 - Unity 6000.3.x / URP / C# 9.0 制約を前提にする。
 - asmdef 依存は下位から上位へ逆流させない。
-- 同名型・同一責務型を複数アセンブリに増やさない。
+- 同名型または同一責務を複数アセンブリに増やさない。
 - Unity `.meta` は資産本体と同じ意味で扱い、移動・削除時に整合させる。
 - `ProjectSettings/` と `Packages/` は高影響面。明確な必要性なしに触らない。
-- コンパイル成功や Unity Editor 上の挙動は、ドキュメント上の推測ではなく検証結果として扱う。
+- コンパイル成功や Unity Editor 上の挙動は、文書上の推測ではなく検証結果として扱う。
 
 ## Responsibility Boundaries
 
 - user: 作品性、最終体験、Unity Editor 上の実機感、凍結 frontier の再開判断。
-- assistant: repo 調査、実装、機械的検証、差分説明、ドキュメント同期。
+- supervisor AI: outcome、bottleneck、creative direction、stop condition の定義と成果レビュー。
+- development AI: repo 調査、実装、機械検証、差分説明、正本同期、成果単位内の判断。
 - tool: テスト、静的チェック、スクリプト実行、ブラウザ/Unity 補助が利用可能な場合の観測。
-- shared: Editor 手動確認が必要な acceptance。
+- shared: Editor 手動確認が必要な acceptance と、その証拠の記録。
 
 ## Prohibited Shortcuts
 
 - `rejected` / `frozen` / `hold` を「未着手だから次に進める」と解釈しない。
 - テストや docs 整備を、ユーザー可視の terrain / structure artifact 進捗として水増ししない。
 - 旧セッションの handover や historical report を、現在の acceptance 証拠として扱わない。
-- ユーザー未指定の外部プロジェクトから規約や成果物を移植しない。比較参照する場合も、明示された範囲だけに限る。
+- ユーザー未指定の外部プロジェクトから規約や成果物を移植しない。比較・参照する場合も、
+  明示された範囲だけに限る。
 
 ## Operating Rule
 
-ユーザーが一度説明した非交渉条件は、同じブロック内でここへ固定する。理由や経緯は `docs/project-context.md` が存在する場合はそちらへ、現在状態は `docs/runtime-state.md` へ置く。
+ユーザーが一度説明した非交渉条件は、同じブロック内でこの正本へ固定する。
+理由や経緯は `docs/project-context.md`、現在状態は `docs/runtime-state.md` に置く。

--- a/docs/NAV.md
+++ b/docs/NAV.md
@@ -15,6 +15,9 @@ Stop there unless the task needs more evidence.
 
 - Product purpose and world-level priority: `docs/SSOT_WORLD.md`
 - Current state and active bottleneck: `docs/runtime-state.md`
+- Public current-state projection: pinned GitHub Issue
+  [#48 Project Pulse](https://github.com/YuShimoji/VastCore/issues/48), generated
+  from `docs/runtime-state.md`
 - Assembly boundaries: `docs/02_design/ASSEMBLY_ARCHITECTURE.md`
 - Code standards: `docs/03_guides/UNITY_CODE_STANDARDS.md`
 - Compile diagnosis: `docs/03_guides/COMPILATION_GUARD_PROTOCOL.md`
@@ -37,6 +40,8 @@ Stop there unless the task needs more evidence.
 - Current restart reports: `docs/restart/`
 - Claude Code pointer: `.claude/CLAUDE.md`
 - Codex local config: `.codex/config.toml`
+- State validation and external projection: `scripts/check-project-state.ps1`
+  and `.github/workflows/project-pulse.yml`
 
 ## Staleness Rule
 

--- a/docs/OPERATOR_WORKFLOW.md
+++ b/docs/OPERATOR_WORKFLOW.md
@@ -1,22 +1,82 @@
 # Operator Workflow
 
-人間オペレーターの実ワークフロー・痛点・品質目標を保持する正本。
+人間オペレーター、監修AI、開発AIの実ワークフロー・痛点・品質目標を保持する正本。
 
 ## Overall Flow
 
-1. Assistant scopes the current artifact and checks repo-local rules.
-2. Assistant implements or prepares the smallest artifact-moving change.
-3. Assistant runs narrow mechanical checks when available.
-4. User performs Unity Editor / scene / visual judgement when acceptance depends
-   on actual editor behavior or creative feel.
-5. Assistant records evidence and syncs only the owning docs.
+1. 監修AIは `runtime-state` と owning artifact を読み、今回変える差分だけを
+   Mission Packet にする。過去経緯や全手順を Prompt に複製しない。
+2. 高コストなUI・ビジュアル・コンテンツ変更だけは、実装前に2〜3方向を
+   比較し、ユーザーが選択または混合して design intent を固定する。
+3. 開発AIは一つの reviewable outcome までを coherent batch として実装し、
+   関連する狭い修正、機械検証、正本同期まで継続する。
+4. 進捗共有は、方針が変わった時、意味のある中間成果が出た時、または長い
+   ツール待ちの時に行う。ファイル単位・コマンド単位では報告しない。
+5. Unity Editor / scene / visual judgement が必要なら、開発AIは機械検証と分離
+   した一つの確認バッチとして対象、操作、成功条件を渡す。
+6. 開発AIは `runtime-state` と必要な owning docs を同期し、検証済み範囲と
+   未検証範囲を分けて commit/push する。
+7. GitHub Project Pulse は `runtime-state` から自動更新し、次のPromptは
+   その current outcome が閉じたか、stop condition に達した時だけ発行する。
+
+並行枝はそれぞれのtask/spec/PRへ進捗を残し、global `runtime-state` を奪い合わない。
+Project Pulse を更新するのは current outcome を所有する一枝だけで、所有枝を変える時は
+handoffとして repository variable `PROJECT_PULSE_BRANCH` と
+`runtime-state` の branch/outcome/next action を同時に更新する。
+
+## Supervisor To Developer Mission Packet
+
+一つのPromptは一つの成果単位を渡す。実装手順の細分化ではなく、以下の契約を
+短く埋める。既知の状態は commit と正本パスで参照し、Prompt本文に複製しない。
+
+```text
+[VASTCORE MISSION]
+Outcome: 完了時に誰が何をできるようになるか
+Why now: 解消する現在の bottleneck
+Scope: 今回含む境界 / 明示的に含まない境界
+Acceptance: 必要なコード・画面・テスト・手動確認の証拠
+Risk tier: routine（既定・自律実行）/ boundary-changing（具体的な危険と判断を記述）
+Autonomy: outcome 内の実装、関連修正、検証、正本同期、commit/push は開発AI判断
+Stop only if: 破壊的変更、依存/DB/認証/API契約、仕様衝突、未確定の高コスト方向
+Creative checkpoint: 不要 / 方向案を先に提示 / 選択済み intent と proof slice
+Sync on close: runtime-state と今回変わる owning artifact
+Start from: branch/commit と必要最小限の task/spec/正本パス
+```
+
+次の作業が Outcome、Scope、Autonomy の内側なら、監修AIは追加のmicro-promptを
+発行せず、開発AIも確認待ちにしない。新しいPromptが必要なのは、成果単位が閉じた、
+stop condition に触れた、またはユーザーが方向を変えた時だけ。
+
+## Direction Before Production
+
+レイアウト、色、フォント、アニメーション、言語対応、コンテンツ拡張など、後から
+直すほど高価になる変更では次の順序を守る。
+
+1. 監修AIまたは開発AIが、表面的な色違いではない2〜3方向を提示する。各案に
+   狙い、利用場面、代償、何が可能になるか、推奨案を添える。
+2. ユーザーの選択・混合・修正を、短い design intent と anti-goals に固定する。
+3. 全面実装ではなく、一画面・一フロー・一代表コンテンツの proof slice を作る。
+4. 実物をまとめてレビューし、承認後に横展開する。
+
+同じ懸念の微修正が2巡しても収束しない、または3件以上の修正が同じ原則に集まる
+場合は、個別調整を止めて direction checkpoint に戻る。これは実装停止ではなく、
+誤った方向への追加投資を止めるための再設計である。
+
+## Creative Exploration Pulse
+
+主要な成果単位を閉じる前に、現在の主レーンとは異なる視点から最大2件だけ提案する。
+UIならレイアウト/情報階層、i18n、色/フォント、motion/accessibility、隣接コンテンツを
+候補レンズにする。各提案には仮説、利得、コスト、今決める意味を添え、未承認の提案を
+成果物へ黙って混ぜない。
 
 ## Actor Boundaries
 
-- user: final visual/creative judgement, Unity Editor acceptance when the editor
-  must be observed, reopening frozen product frontiers.
+- user: direction checkpoint の選択、final visual/creative judgement、Unity
+  Editor acceptance、frozen product frontier の再開。
+- supervisor AI: outcome と bottleneck の定義、異なる方向案、stop condition、
+  成果レビュー。実装手順の逐次指示は担当しない。
 - assistant: source edits, doc sync, static checks, focused tests, readback, gap
-  reports.
+  reports, outcome 内の実装判断、creative option の具体化。
 - tool: scripted checks, local servers, browser or editor automation when
   available and task-relevant.
 - shared: manual Editor verification followed by assistant evidence capture.
@@ -36,9 +96,15 @@
 - Spreading the same rule across `AGENTS.md`, `CLAUDE.md`, docs, and tool config.
 - Asking the user to choose between commit/no-commit instead of explaining the
   actual bottleneck.
+- Treating every safe implementation choice as a new approval gate.
+- Delivering a broad visual result before direction is selected, then spending
+  repeated blocks on local polish without revisiting the design intent.
+- Writing progress only in chat or a historical handoff while leaving
+  `runtime-state` and the external Project Pulse stale.
 
 ## Quality Goal
 
 The workflow is healthy when a new agent can read the normal 3-file restart set,
-identify the current artifact and bottleneck, and know which doc owns any deeper
-evidence it needs.
+identify the current outcome and bottleneck, finish a coherent batch without a
+micro-prompt chain, and leave both the repo state and public Project Pulse ready
+for the next decision.

--- a/docs/REPO_LOCAL_RULES.md
+++ b/docs/REPO_LOCAL_RULES.md
@@ -43,6 +43,42 @@ exception, not progress by itself.
 - Do not present documentation cleanup as product progress unless it makes the
   active artifact path easier, safer, or more verifiable.
 
+## Execution Default And Stops
+
+- Treat one supervisor prompt as authority to complete one coherent outcome,
+  including related narrow fixes, verification, state sync, commit, and push.
+  Do not stop after each file, command, or reversible implementation choice.
+- For safe in-repo uncertainty, state the assumption, take the smallest
+  reversible path, and verify it. A possible risk without a concrete harmful
+  consequence is not a stop reason.
+- Stop only when the next action would cross the approved outcome or materially
+  change a destructive operation, dependency, database, authentication, public
+  API/serialization contract, product invariant, or unresolved high-cost
+  creative direction.
+- A failed check is evidence, not an automatic new mission. Run one bounded
+  diagnostic pass, record the exact blocker, then continue any work that does
+  not depend on the failed check.
+- For costly user-visible UX, visual, or content work, establish direction with
+  two or three genuinely different routes before broad implementation. Once a
+  route and proof slice are selected, execute that slice without asking again
+  for routine details inside the agreed intent.
+
+## State Sync Is Part Of Completion
+
+- Update `docs/runtime-state.md` in the same block when the branch, active
+  outcome/artifact, bottleneck, trust evidence, acceptance state, or next action
+  changes.
+- Record durable user corrections in `docs/USER_REQUEST_LEDGER.md`; update
+  `docs/OPERATOR_WORKFLOW.md` when the human/AI working agreement changes.
+- The public Project Pulse is a generated projection of `runtime-state`, not a
+  second source of truth. Never maintain its status text by hand.
+- Only the branch that owns the declared current outcome may rewrite the global
+  `runtime-state` position and publish Project Pulse. Parallel branches update
+  their owning task/spec/PR until an explicit handoff makes one of them current.
+- Repository variable `PROJECT_PULSE_BRANCH` names that single publishing branch.
+  A branch handoff updates the variable and `runtime-state` together; validation
+  remains read-only on all other branches.
+
 ## Unity Engineering Rules
 
 - Before code changes, identify the owning assembly and check
@@ -92,5 +128,7 @@ evidence, residual risk, recommended default, and next owner.
 - Do not ask broad questions when repo evidence can decide the next move.
 - Offer options only when they solve different bottlenecks.
 - Do not mix manual verification with next-direction choice in one ask.
+- Batch non-blocking uncertainties. Ask mid-block only when the answer changes
+  the outcome, crosses a stop condition, or prevents meaningful progress.
 - When corrected, verify against repo evidence and make the smallest safe fix in
   the same block.

--- a/docs/USER_REQUEST_LEDGER.md
+++ b/docs/USER_REQUEST_LEDGER.md
@@ -11,6 +11,22 @@
 - Treat missing referenced docs as stale references, not blockers.
 - For residual work, report purpose, effect, requirements, current state, owner,
   and next move.
+- 2026-07-10: Supervisor prompts and development execution must optimize for one
+  coherent outcome, not a chain of tiny instructions. Safe, reversible, in-scope
+  work should continue through related fixes and verification without repeated
+  approval.
+- 2026-07-10: Safety gates must not become the main work. Stop only for a
+  concrete destructive/contract/authority conflict or an unresolved expensive
+  creative direction.
+- 2026-07-10: Progress and next work must remain understandable outside chat.
+  Keep repo state current and publish a generated external Project Pulse rather
+  than relying on manually maintained Wiki prose.
+- 2026-07-10: AI reviews must contribute creative alternatives across layout,
+  localization, content adjacency, color, typography, and motion when relevant.
+  Expensive production starts only after the user can compare directions.
+- 2026-07-10: Avoid the broad-delivery-to-micro-tweak loop. Use an early
+  direction checkpoint, a small proof slice, batched review, and return to the
+  design principle when local tweaks do not converge after two rounds.
 
 ## Standing Reporting Preferences
 
@@ -22,6 +38,8 @@
 - When the user asks to keep context in the project and make another terminal
   resume immediately, update repo-local state/handoff docs and push that state
   instead of leaving the handoff only in chat.
+- Prefer a small number of enforced owners and automation over adding more
+  overlapping instruction resources.
 
 ## Backlog Delta
 

--- a/docs/ai/CORE_RULESET.md
+++ b/docs/ai/CORE_RULESET.md
@@ -28,8 +28,9 @@ residual-work reporting live in `docs/REPO_LOCAL_RULES.md`.
 
 ### Artifact-first
 
-Advance the active artifact or its verified delivery path. Docs, cleanup, tests,
-mocks, and surveys are supporting work unless they unblock that path.
+Advance the active artifact or its verified delivery path through one coherent
+outcome. Docs, cleanup, tests, mocks, and surveys are supporting work unless they
+unblock that path. Coherent does not mean smallest possible micro-step.
 
 ### Explain Once Canonicalization
 
@@ -53,7 +54,9 @@ normal next steps. User interest in "looking again" is not approval.
 
 If the user chooses a proposed item for deeper review, that means
 "evaluate/specify this next", not "approve implementation". Keep status semantics
-strict.
+strict. An explicit direction choice inside an already approved Mission Packet
+does authorize the named proof slice when the packet says so; do not turn that
+choice into another generic approval round.
 
 ### No Pendulum Compensation
 

--- a/docs/ai/DECISION_GATES.md
+++ b/docs/ai/DECISION_GATES.md
@@ -2,6 +2,19 @@
 Ruleset-Version: v20
 Status: canonical
 
+## Risk-Proportional Autonomy Gate
+
+These gates filter exceptional boundary crossings; they are not a checklist of
+approvals for ordinary work. Continue through reversible, in-repo decisions
+inside the current Mission Packet. Pause only when the action would materially
+change a destructive operation, dependency, database, authentication, public
+API/serialization contract, product invariant, or unresolved expensive creative
+direction. Name the hazard, consequence, and decision when pausing.
+
+If a check fails, spend one bounded pass distinguishing product failure from
+tool/environment failure. Record the blocker and continue work that does not
+depend on that check; do not make safety diagnosis the next mission by default.
+
 ## Active Artifact and Change Relation
 
 Each block must know:
@@ -87,6 +100,10 @@ If the project depends on a human-authored or editor-driven production workflow,
 do not jump to quantity expansion before the workflow has been proven once
 end-to-end.
 
+This gate explicitly permits the one representative proof slice named by an
+approved Mission Packet. It blocks premature scaling, not the evidence needed to
+make the direction reviewable.
+
 Examples:
 
 - author -> validate -> generate -> preview
@@ -126,3 +143,4 @@ Before asking:
 - keep one intent per ask
 - do not mix manual verification with next-direction choice
 - do not use procedural yes/no traps as the main options
+- batch non-blocking uncertainty and continue on a stated reversible assumption

--- a/docs/ai/WORKFLOWS_AND_PHASES.md
+++ b/docs/ai/WORKFLOWS_AND_PHASES.md
@@ -42,6 +42,15 @@ implementation block that needs the write.
   belong in project docs.
 - When a prompt and repo docs differ, update or ignore the prompt; do not
   override repo docs with prompt text.
+- A supervisor prompt should be one Mission Packet: outcome, bottleneck, scope,
+  acceptance evidence, autonomy, concrete stop conditions, creative checkpoint,
+  sync targets, and start commit/docs. It is not a command transcript.
+- The packet must authorize implementation, adjacent narrow fixes, verification,
+  state sync, commit, and push inside its outcome. Do not issue a new prompt for
+  each of those steps.
+- Continue without a new prompt while the next action remains inside outcome,
+  scope, and autonomy. Re-prompt only after outcome closure, a stop condition,
+  or a user direction change.
 
 ## Scout Requirements
 
@@ -77,6 +86,11 @@ Each major option should show:
 
 Avoid options whose main meaning is merely commit / not commit / cleanup only /
 end.
+
+For user-visible creative work, generate two or three directions before broad
+production. Vary the underlying information hierarchy, interaction model, or
+visual/content strategy rather than producing cosmetic variants. After a route
+is selected, implement one representative proof slice before scaling.
 
 ## Commit and Push Hygiene
 

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -8,6 +8,14 @@ evidence, but they are not current acceptance unless re-verified.
 
 ## Decision Log
 
+- 2026-07-10: Supervisor-to-developer work is outcome-based. A Mission Packet
+  authorizes one coherent implementation/verification/state-sync batch; only
+  concrete destructive or contract boundaries and unresolved expensive creative
+  direction require a mid-block stop.
+- 2026-07-10: `docs/runtime-state.md` remains the narrative current-state SSOT.
+  A pinned GitHub Project Pulse issue is a generated external projection, while
+  Wiki/Pages remain candidates for durable reference material rather than live
+  status.
 - 2026-06-29: VC-RST-2 remote resume handoff was refreshed after the T+2n
   network/proxy/env audit. Network/proxy/env is now weakened as the direct UPM
   root; the next discriminator is user-approved Unity Editor / embedded UPM
@@ -29,21 +37,13 @@ evidence, but they are not current acceptance unless re-verified.
   `docs/architecture/`. These docs record current compile and dependency risks;
   they do not approve a broad refactor or claim Unity acceptance.
 
-## Handoff Notes
+## Historical Handoff Index
 
-- Current remote resume handoff:
-  `docs/restart/VC_REMOTE_RESUME_HANDOFF_20260629.md`.
-- Current active artifact:
-  `docs/restart/VC_UPM_NETWORK_PROXY_ENV_AUDIT.md`.
-- Next action: `VC-RST-2o-editor-repair-retest` after user-approved Unity
-  Editor / embedded UPM repair or reinstall. The Agent should retest a
-  short-path empty-manifest control before reopening VastCore.
-- Future handoffs should reference the active artifact and bottleneck from
-  `docs/runtime-state.md`.
-- VC-RST-2 restart context is tracked in
-  `docs/restart/VC_PACKAGE_MANAGER_RESTORATION_REPORT.md`. A next terminal
-  should recreate or locate a clean `origin/main` worktree before touching
-  `Packages/`, `ProjectSettings/`, generated folders, or Unity batchmode.
-- Remote sync for this block should include the restart report and the current
-  trust boundary that Unity Package Manager, compile, and runtime behavior still
-  need re-check.
+- Current state, active artifact, bottleneck, and next action always come from
+  `docs/runtime-state.md`; historical entries below are evidence only.
+- Designer Cockpit UX review handoff:
+  `docs/restart/VC_DESIGNER_COCKPIT_UX_REMOTE_REVIEW_HANDOFF.md`.
+- VC-RST-2 package restoration history:
+  `docs/restart/VC_PACKAGE_MANAGER_RESTORATION_REPORT.md`.
+- Earlier remote-resume packets under `docs/restart/` must not override current
+  evidence without re-verification.

--- a/docs/runtime-state.md
+++ b/docs/runtime-state.md
@@ -13,7 +13,7 @@ Last Updated: 2026-07-10
 | Active artifact | `docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md` |
 | Product artifact | `docs/DESIGNER_COCKPIT_SMOKE_TEST.md` |
 | Current bottleneck | Git and source editing are ready; Unity batchmode still exits before C# compile with UPM `path undefined`, and the Designer Cockpit has not received its in-Editor manual smoke/layout acceptance |
-| Batch boundary | Workflow docs, state validation, and external Project Pulse only; no `Assets`, `Packages`, `ProjectSettings`, dependency, or product-code change in this branch |
+| Batch boundary | Workflow docs/automation, state validation, and external Project Pulse only; no `Assets`, `Packages`, `ProjectSettings`, dependency, or product-code change in this branch |
 | Change relation | unblocker |
 
 ## Current Block
@@ -36,6 +36,12 @@ Completed or verified in this block:
   plus GitHub Project Pulse automation.
 - Created and pinned Project Pulse Issue #48; repository variables identify its
   issue number and this branch as the single authorized publishing source.
+- Verified GitHub Actions run `29082183177`: canonical state validation and
+  Project Pulse publication both passed, and Issue #48 was updated from this
+  branch. The new workflow now uses the current checkout/github-script majors.
+- The same push exposed an existing invalid Unity workflow before any job ran.
+  Replaced the direct secret-in-job-condition with a license-gate output and
+  aligned its configured Editor from 6000.2.2f1 to project version 6000.3.6f1.
 - Restored the canonical `docs/INVARIANTS.md` from mojibake to readable Japanese.
 - Removed stale "current" claims from `docs/project-context.md`; historical
   handoffs remain evidence only.
@@ -61,8 +67,12 @@ Deliberately not changed:
 - Trusted: Unity Editor 6000.3.6f1, Git 2.50.1, and Node 22.19.0 are installed.
 - Trusted: the latest batch log at `artifacts/logs/compile-check.log` reproduces
   the known UPM failure before package load and before C# compilation.
+- Trusted: GitHub Actions run `29082183177` passed both Project State and Pulse
+  jobs and updated the pinned external issue from the configured owner branch.
 - Not accepted: current C# compile, EditMode/PlayMode tests, Cockpit layout,
   Random Variation Apply/Undo, and session save/load in the Editor.
+- Not configured: repository secret `UNITY_LICENSE`; the repaired Actions
+  workflow must report Unity test jobs as skipped until that secret exists.
 - External visibility risk: GitHub still defaults to obsolete `master`; Project
   Pulse mitigates current-state visibility but does not replace baseline repair.
 

--- a/docs/runtime-state.md
+++ b/docs/runtime-state.md
@@ -1,118 +1,101 @@
 # VastCore Runtime State
 
-Last Updated: 2026-07-07
+Last Updated: 2026-07-10
 
 ## Current Position
 
 | Field | Value |
 |---|---|
 | Project | VastCore Terrain Engine |
-| Branch | `codex/vc-rst-cockpit-ux-diagnostics-20260706` |
-| Active artifact | `docs/04_reports/REPORT_DESIGNER_COCKPIT_UX_DIAGNOSTICS_2026-07-06.md` |
-| Current bottleneck | Designer Cockpit MVP is implemented and the UX diagnostics slice is pushed as a remote review branch; Unity batchmode is blocked by the known UPM `path undefined` failure, and the next acceptance bottleneck is an in-Unity manual smoke/layout pass. |
-| Change relation | designer-facing Unity Editor cockpit / mode-based authoring UX / local session save-load MVP / compile and smoke evidence follow-through |
+| Branch | `codex/vc-ai-workflow-refresh-20260710` |
+| Integrated baseline | `fd1cb29` from `origin/codex/vc-rst-cockpit-ux-diagnostics-20260706` |
+| Active outcome | Make supervisor-to-developer work outcome-based, keep current state visible outside chat, and preserve the Cockpit review path |
+| Active artifact | `docs/04_reports/REPORT_AI_COLLABORATION_WORKFLOW_REFRESH_2026-07-10.md` |
+| Product artifact | `docs/DESIGNER_COCKPIT_SMOKE_TEST.md` |
+| Current bottleneck | Git and source editing are ready; Unity batchmode still exits before C# compile with UPM `path undefined`, and the Designer Cockpit has not received its in-Editor manual smoke/layout acceptance |
+| Batch boundary | Workflow docs, state validation, and external Project Pulse only; no `Assets`, `Packages`, `ProjectSettings`, dependency, or product-code change in this branch |
+| Change relation | unblocker |
 
 ## Current Block
 
-Purpose: advance the project from compile-restoration handoff into a reviewable
-designer-facing Editor cockpit while keeping incomplete systems visibly honest.
+Completed or verified in this block:
 
-Completed in this block:
+- Fetched all remote branches and tags with prune, then ran `git pull --ff-only`.
+  The prior Cockpit UX branch is exactly at its remote tip `fd1cb29`.
+- Fast-forwarded local `main` from `a9e7142` to `origin/main` at `39f790c`;
+  no unique local `main` commits were discarded.
+- Created `codex/vc-ai-workflow-refresh-20260710` from the latest Cockpit UX tip
+  so workflow changes do not contaminate the product review branch.
+- Re-ran `scripts/check-compile.ps1` with Unity 6000.3.6f1. It exited 1 after
+  Package Manager reported `The "path" argument must be of type string. Received
+  undefined. No packages loaded.` No C# compiler error was reached.
+- Replaced micro-prompt behavior with an outcome-based Mission Packet, bounded
+  autonomy, concrete stop conditions, an early creative direction checkpoint,
+  proof-slice review, and a two-round escape from local tweak loops.
+- Made runtime-state/owning-doc sync part of completion and added a state check
+  plus GitHub Project Pulse automation.
+- Created and pinned Project Pulse Issue #48; repository variables identify its
+  issue number and this branch as the single authorized publishing source.
+- Restored the canonical `docs/INVARIANTS.md` from mojibake to readable Japanese.
+- Removed stale "current" claims from `docs/project-context.md`; historical
+  handoffs remain evidence only.
 
-- Added standalone `Tools/VastCore/Designer Cockpit` EditorWindow.
-- Added `VastCoreDesignerSession` ScriptableObject and `RandomTransformRecipe`.
-- Implemented local session new/save/load flow.
-- Implemented deterministic random transform application for selected scene
-  objects with Undo.
-- Added status sections for RandomControl, Composition, Deform, Terrain, and
-  future Topology/DualGrid.
-- Added smoke checklist and cockpit/pipeline navigation docs.
-- Added sample session asset at
-  `Assets/Data/VastCore/DesignerSessions/Designer_Session.asset`.
-- Refreshed `docs/04_reports/LEGACY_UI_MIGRATION_REPORT.md` so the new
-  Cockpit `OnGUI` surface is visible in the dry-run UI migration report.
-- Restored stale `TerrainGenerator.TerrainGenerationMode` references to the
-  current `TerrainGenerationMode` API in editor/test code.
-- Fixed adjacent editor compile blockers in `StructureGeneratorWindow.cs` and
-  `PhaseCVerificationSetup.cs`.
-- Restored stale test enum references using narrow type aliases.
-- Reorganized the Cockpit into top summary, primary action row, mode selector,
-  concise mode panels, Random Variation controls, Advanced ranges, and
-  Diagnostics.
-- Updated the smoke checklist and cockpit overview so reviewer work follows the
-  current mode-based UX instead of the older always-visible parameter surface.
-- Captured UX diagnostics notes and report artifacts for the mode-based Cockpit
-  slice.
-- Packaged and pushed the UX diagnostics diff to
-  `origin/codex/vc-rst-cockpit-ux-diagnostics-20260706` at commit `55440cf`.
-- Added remote review handoff at
-  `docs/restart/VC_DESIGNER_COCKPIT_UX_REMOTE_REVIEW_HANDOFF.md`.
+Deliberately not changed:
 
-Out of scope for this block:
-
-- DualGrid/topology algorithm or preview implementation.
-- CSG/Blend runtime verification.
-- Deform package runtime verification.
-- Terrain generation runtime smoke.
-- Gameplay/player/Trail/combat/story systems.
-- Public release, cloud sync, external services, or production acceptance.
+- Designer Cockpit source, sessions, sample assets, and Unity `.meta` files.
+- `Packages/`, `ProjectSettings/`, Unity installation, caches, or other running
+  Unity projects.
+- Five existing stashes and two other worktrees.
+- The divergent remote-handoff branch with mixed package/settings/deletion work.
+- Broad deletion/archive of old workflow SSOT, indexes, and restart reports.
+- GitHub default branch, branch protection, or the existing conflicting draft PR.
 
 ## Current Trust Assessment
 
-- Trusted: current repo path `C:\Users\PLANNER007\VastCore\VastCore`.
-- Trusted: current local branch
-  `codex/vc-rst-cockpit-ux-diagnostics-20260706` is at parity `0 0` with
-  `origin/codex/vc-rst-cockpit-ux-diagnostics-20260706` after push.
-- Trusted: review branch commit `55440cf` contains the Cockpit UX diagnostics
-  code and docs diff.
-- Trusted: menu entry exists at `Tools/VastCore/Designer Cockpit`.
-- Trusted: session save path is code-owned as
-  `Assets/Data/VastCore/DesignerSessions`.
-- Trusted: sample session asset exists at
-  `Assets/Data/VastCore/DesignerSessions/Designer_Session.asset`.
-- Historical validation: the remote handoff recorded a prior Unity batchmode C#
-  compile success.
-- Current validation log: `artifacts/logs/compile-check.log` now records the
-  Package Manager `path undefined` failure from the latest local rerun.
-- Trusted: `git diff --check` passes with only CRLF normalization warnings.
-- Trusted: menu/class duplicate search found one Cockpit menu item and one
-  `VastCoreDesignerCockpitWindow` class.
-- Current validation blocker: `scripts/check-compile.ps1` exits 1 before C#
-  compile because Package Manager reports `The "path" argument must be of type
-  string. Received undefined. No packages loaded.`
-- Current narrow compiler rerun: inconclusive; direct `csc` invocation reached
-  Unity/NetStandard/IMGUI reference-set setup failures, not a Cockpit source
-  diagnostic.
-- Needs re-check: manual Unity Editor smoke for open/apply/Undo/save/load.
-- Needs re-check: editmode/playmode test execution; this block ran compile
-  check only.
-- Needs re-check: visual layout in the Unity Editor window; no screenshot/manual
-  cockpit inspection was performed.
-- Tooling context: `.serena/project.yml` was refreshed by Serena activation and
-  is included in the remote sync only to leave the next terminal with the same
-  project tooling state.
+- Trusted: `origin/codex/vc-rst-cockpit-ux-diagnostics-20260706` and the local
+  integrated baseline are both `fd1cb29116e6462684d91252a715e7eea3b563b6`.
+- Trusted: `origin/main` is a direct ancestor of that baseline and local `main`
+  now matches `origin/main` at `39f790c`.
+- Trusted: the workflow refresh started from a clean worktree; product code and
+  Unity configuration are untouched in this branch.
+- Trusted: Unity Editor 6000.3.6f1, Git 2.50.1, and Node 22.19.0 are installed.
+- Trusted: the latest batch log at `artifacts/logs/compile-check.log` reproduces
+  the known UPM failure before package load and before C# compilation.
+- Not accepted: current C# compile, EditMode/PlayMode tests, Cockpit layout,
+  Random Variation Apply/Undo, and session save/load in the Editor.
+- External visibility risk: GitHub still defaults to obsolete `master`; Project
+  Pulse mitigates current-state visibility but does not replace baseline repair.
+
+## Open Decisions
+
+- Review and adopt the Mission Packet/autonomy/direction-checkpoint contract.
+- After Cockpit acceptance, fast-forward the accepted tip to `main`, change the
+  GitHub default from `master` to `main`, and align protections/workflows.
+- Run a separate reference-aware Excise slice before deleting or archiving old
+  SSOT/index/handoff documents.
 
 ## Next Action
 
-Run the manual smoke checklist in `docs/DESIGNER_COCKPIT_SMOKE_TEST.md` against
-the current mode-based Cockpit:
+Use `docs/DESIGNER_COCKPIT_SMOKE_TEST.md` as one batched manual acceptance pass:
 
-1. Open `Tools/VastCore/Designer Cockpit`.
-2. Confirm the top summary, primary actions, mode selector, and Diagnostics
-   drawer layout.
-3. Switch through Overview, Random Variation, Terrain, Composition, Deform, and
-   Diagnostics.
-4. Select objects, apply Random Variation, and verify Undo restores transforms.
-5. Save a session asset under `Assets/Data/VastCore/DesignerSessions`.
-6. Create a new session, load the saved asset, and confirm fields restore.
+1. Open `Tools/VastCore/Designer Cockpit` and inspect the top summary, primary
+   actions, mode selector, mode panels, and Diagnostics drawer.
+2. Apply Random Variation to selected objects and verify Undo.
+3. Save, create a new session, reload, and verify restored fields.
+4. Capture the layout result and all functional checks together, then update the
+   Cockpit evidence and choose whether to advance, revise direction, or repair
+   the Unity environment.
 
-After smoke evidence exists, the next likely slice is to capture SG-2 dashboard
-smoke results, promote verified evidence into Cockpit Evidence Tiles, or feed
-CT-1 Composition verification into Diagnostics.
+If the Editor cannot reach the Cockpit because of the same UPM failure, record
+that once as an environment blocker and do not split it into another chain of
+micro-prompts.
 
-## Remote Handoff
+## External Pulse
 
-Read `docs/restart/VC_DESIGNER_COCKPIT_UX_REMOTE_REVIEW_HANDOFF.md` for the
-compact cross-terminal packet after fetching this branch. The older
-`docs/restart/VC_DESIGNER_COCKPIT_REMOTE_HANDOFF_REPORT.md` describes the base
-MVP handoff before this UX review branch.
+The pinned GitHub issue
+[#48 Project Pulse](https://github.com/YuShimoji/VastCore/issues/48) is generated
+from this file by `.github/workflows/project-pulse.yml`. This file remains the
+authoritative source; the issue is the public projection and discussion surface.
+Repository variable `PROJECT_PULSE_BRANCH` currently assigns publication to
+`codex/vc-ai-workflow-refresh-20260710` and must move with an explicit branch
+handoff.

--- a/docs/runtime-state.md
+++ b/docs/runtime-state.md
@@ -39,9 +39,15 @@ Completed or verified in this block:
 - Verified GitHub Actions run `29082183177`: canonical state validation and
   Project Pulse publication both passed, and Issue #48 was updated from this
   branch. The new workflow now uses the current checkout/github-script majors.
+- Verified follow-up run `29083404696` with those current action majors; both
+  jobs passed without the prior Node runtime warning.
 - The same push exposed an existing invalid Unity workflow before any job ran.
   Replaced the direct secret-in-job-condition with a license-gate output and
   aligned its configured Editor from 6000.2.2f1 to project version 6000.3.6f1.
+- Dispatched repaired Unity workflow run `29083435552`: license-gate passed and
+  the Unity test job was correctly skipped because no license secret exists.
+- Opened draft PR #49 against the preceding Cockpit UX branch so review contains
+  only this workflow refresh rather than 349 commits from obsolete `master`.
 - Restored the canonical `docs/INVARIANTS.md` from mojibake to readable Japanese.
 - Removed stale "current" claims from `docs/project-context.md`; historical
   handoffs remain evidence only.
@@ -69,6 +75,8 @@ Deliberately not changed:
   the known UPM failure before package load and before C# compilation.
 - Trusted: GitHub Actions run `29082183177` passed both Project State and Pulse
   jobs and updated the pinned external issue from the configured owner branch.
+- Trusted: follow-up Pulse run `29083404696` passed on current action majors;
+  Unity workflow dispatch `29083435552` passed its gate and skipped tests.
 - Not accepted: current C# compile, EditMode/PlayMode tests, Cockpit layout,
   Random Variation Apply/Undo, and session save/load in the Editor.
 - Not configured: repository secret `UNITY_LICENSE`; the repaired Actions
@@ -108,4 +116,5 @@ from this file by `.github/workflows/project-pulse.yml`. This file remains the
 authoritative source; the issue is the public projection and discussion surface.
 Repository variable `PROJECT_PULSE_BRANCH` currently assigns publication to
 `codex/vc-ai-workflow-refresh-20260710` and must move with an explicit branch
-handoff.
+handoff. The active review surface is draft PR
+[#49](https://github.com/YuShimoji/VastCore/pull/49).

--- a/docs/runtime-state.md
+++ b/docs/runtime-state.md
@@ -48,6 +48,8 @@ Completed or verified in this block:
   the Unity test job was correctly skipped because no license secret exists.
 - Opened draft PR #49 against the preceding Cockpit UX branch so review contains
   only this workflow refresh rather than 349 commits from obsolete `master`.
+- Added the remote-resume procedure to this canonical state file so another
+  terminal can recover without a new one-off handoff document.
 - Restored the canonical `docs/INVARIANTS.md` from mojibake to readable Japanese.
 - Removed stale "current" claims from `docs/project-context.md`; historical
   handoffs remain evidence only.
@@ -118,3 +120,37 @@ Repository variable `PROJECT_PULSE_BRANCH` currently assigns publication to
 `codex/vc-ai-workflow-refresh-20260710` and must move with an explicit branch
 handoff. The active review surface is draft PR
 [#49](https://github.com/YuShimoji/VastCore/pull/49).
+
+## Remote Resume
+
+Do not start from GitHub's default `master`; it is obsolete. The current remote
+handoff is the branch and draft PR named above.
+
+For an existing clone that already has the local branch:
+
+```powershell
+git fetch origin --prune
+git switch codex/vc-ai-workflow-refresh-20260710
+git pull --ff-only
+```
+
+For a clone that does not yet have the local branch:
+
+```powershell
+git fetch origin --prune
+git switch --track origin/codex/vc-ai-workflow-refresh-20260710
+```
+
+Then read only the normal restart set and validate the recovered state:
+
+```powershell
+Get-Content AGENTS.md
+Get-Content docs/REPO_LOCAL_RULES.md
+Get-Content docs/runtime-state.md
+.\scripts\check-project-state.ps1 -ExpectedBranch codex/vc-ai-workflow-refresh-20260710
+```
+
+Resume from `## Next Action`. Use PR #49 for the workflow diff and Issue #48 for
+the public current-state projection. Do not merge old draft PR #47, apply the
+five historical stashes, modify the two other worktrees, or restart the old UPM
+diagnostic chain unless new evidence changes the current bottleneck.

--- a/scripts/check-project-state.ps1
+++ b/scripts/check-project-state.ps1
@@ -1,0 +1,123 @@
+[CmdletBinding()]
+param(
+    [string]$StatePath = 'docs/runtime-state.md',
+    [string]$ExpectedBranch = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$errors = [System.Collections.Generic.List[string]]::new()
+$strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+$commonMojibakeChars = @(
+    [char]0x7E3A,
+    [char]0x7E67,
+    [char]0x8B41,
+    [char]0x873F,
+    [char]0x8B07
+)
+
+function Add-StateError {
+    param([string]$Message)
+    $errors.Add($Message)
+}
+
+function Read-StrictUtf8 {
+    param([string]$RelativePath)
+
+    $fullPath = Join-Path $repoRoot $RelativePath
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        Add-StateError "Missing canonical file: $RelativePath"
+        return ''
+    }
+
+    try {
+        return $strictUtf8.GetString([System.IO.File]::ReadAllBytes($fullPath))
+    }
+    catch {
+        Add-StateError "File is not valid UTF-8: $RelativePath ($($_.Exception.Message))"
+        return ''
+    }
+}
+
+$canonicalPaths = @(
+    'AGENTS.md',
+    'docs/REPO_LOCAL_RULES.md',
+    'docs/runtime-state.md',
+    'docs/INVARIANTS.md',
+    'docs/USER_REQUEST_LEDGER.md',
+    'docs/OPERATOR_WORKFLOW.md',
+    'docs/INTERACTION_NOTES.md',
+    'docs/project-context.md',
+    'docs/ai/CORE_RULESET.md',
+    'docs/ai/DECISION_GATES.md',
+    'docs/ai/STATUS_AND_HANDOFF.md',
+    'docs/ai/WORKFLOWS_AND_PHASES.md'
+)
+
+foreach ($path in $canonicalPaths) {
+    $text = Read-StrictUtf8 $path
+    $hasCommonMojibake = $commonMojibakeChars | Where-Object { $text.Contains($_) }
+    if ($text.Contains([char]0xFFFD) -or $hasCommonMojibake) {
+        Add-StateError "Possible mojibake in canonical file: $path"
+    }
+}
+
+$state = Read-StrictUtf8 $StatePath
+foreach ($heading in @('# VastCore Runtime State', '## Current Position', '## Current Trust Assessment', '## Next Action')) {
+    if (-not $state.Contains($heading)) {
+        Add-StateError "runtime-state is missing required heading: $heading"
+    }
+}
+
+$dateMatch = [regex]::Match($state, '(?m)^Last Updated:\s*(\d{4}-\d{2}-\d{2})\s*$')
+if (-not $dateMatch.Success) {
+    Add-StateError 'runtime-state must contain Last Updated: YYYY-MM-DD.'
+}
+else {
+    $updated = [DateTime]::MinValue
+    if (-not [DateTime]::TryParseExact(
+            $dateMatch.Groups[1].Value,
+            'yyyy-MM-dd',
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::None,
+            [ref]$updated)) {
+        Add-StateError "Invalid Last Updated date: $($dateMatch.Groups[1].Value)"
+    }
+    elseif ($updated.Date -gt [DateTime]::UtcNow.Date.AddDays(1)) {
+        Add-StateError "Last Updated is unexpectedly in the future: $($updated.ToString('yyyy-MM-dd'))"
+    }
+}
+
+$branchMatch = [regex]::Match($state, '(?m)^\|\s*Branch\s*\|\s*`([^`]+)`\s*\|')
+if (-not $branchMatch.Success) {
+    Add-StateError 'runtime-state Current Position must contain a Branch table row.'
+}
+elseif ($ExpectedBranch -and $branchMatch.Groups[1].Value -ne $ExpectedBranch) {
+    Add-StateError "runtime-state branch '$($branchMatch.Groups[1].Value)' does not match '$ExpectedBranch'."
+}
+
+$artifactMatch = [regex]::Match($state, '(?m)^\|\s*Active artifact\s*\|\s*`([^`]+)`\s*\|')
+if (-not $artifactMatch.Success) {
+    Add-StateError 'runtime-state Current Position must contain an Active artifact table row.'
+}
+else {
+    $artifact = $artifactMatch.Groups[1].Value.Replace('/', [IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path -LiteralPath (Join-Path $repoRoot $artifact) -PathType Leaf)) {
+        Add-StateError "Active artifact does not exist: $($artifactMatch.Groups[1].Value)"
+    }
+}
+
+foreach ($field in @('Project', 'Current bottleneck', 'Change relation')) {
+    if ($state -notmatch "(?m)^\|\s*$([regex]::Escape($field))\s*\|") {
+        Add-StateError "runtime-state Current Position is missing table field: $field"
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Host "ERROR: $_" -ForegroundColor Red }
+    throw "Project state validation failed with $($errors.Count) error(s)."
+}
+
+$reportedBranch = $branchMatch.Groups[1].Value
+$reportedDate = $dateMatch.Groups[1].Value
+Write-Host "Project state OK: branch=$reportedBranch updated=$reportedDate artifact=$($artifactMatch.Groups[1].Value)"


### PR DESCRIPTION
## 変更内容

- 監修AIから開発AIへの指示を、micro-prompt列ではなく一つのreviewable outcomeを渡すMission Packetへ変更
- 可逆な通常作業の自律範囲、具体的な停止条件、creative direction checkpoint、proof slice、微修正ループ脱出条件を正本へ追加
- `docs/runtime-state.md`を検証し、固定Issue #48へ投影するProject Pulse workflowを追加
- 文字化けしていたcanonical `docs/INVARIANTS.md`を可読な日本語へ復元
- 既存Unity Tests workflowの無効なsecret gateを修正し、Editor versionを6000.3.6f1へ同期
- リモート/Git/Unity/外部状態と今後の選択肢を2026-07-10報告へ集約

## 目的

安全gateと細切れhandoffが成果物開発より主作業化し、進捗がchatや古い文書へ分散していたため。通常作業は一成果単位まで継続し、高コストなcreative方向だけを実装前に比較し、外部現在地を手作業なしで保つ。

## 検証

- `scripts/check-project-state.ps1`：PASS（branch/date/active artifact/UTF-8/canonical docs）
- workflow YAML parse：PASS
- `actions/github-script` JavaScript parse：PASS
- `git diff --check`：PASS
- Project State and Pulse run 29082183177 / 29083404696：validate・publishともPASS、Issue #48更新済み
- Unity Tests run 29083435552：license-gate PASS、`UNITY_LICENSE`未設定のためtest jobは意図どおりSKIP
- ローカルUnity batch compile：既知UPM `path undefined / No packages loaded`でC# compile前にexit 1

## 境界

`Assets/`、`Packages/`、`ProjectSettings/`、製品コード、既存stash、別worktreeは変更していない。baseは最新Cockpit UX枝で、古いdefault `master`や競合中の旧PRを混ぜない。